### PR TITLE
implement GetPrimaryBitDepth

### DIFF
--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -9,7 +9,7 @@ HRESULT MxDirectDraw::SetEntries()
 {
   HRESULT ret;
 
-  if (m_unk848) {
+  if (m_paletteIndexed8) {
     if (m_ddpal) {
       ret = m_ddpal->SetEntries(0, 0, 256, m_pal1);
       if (ret != DD_OK) {
@@ -112,7 +112,7 @@ HRESULT MxDirectDraw::FUN_1009e750()
 {
   HRESULT ret;
 
-  if (m_fullScreen && m_unk848) {
+  if (m_fullScreen && m_paletteIndexed8) {
     if (m_ddpal) {
       ret = m_ddpal->SetEntries(0, 0, 256, m_pal0);
       if (ret != DD_OK) {

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -61,7 +61,7 @@ int MxDirectDraw::GetPrimaryBitDepth()
   if (!result)
   {
     memset(&ddsd, 0, sizeof(ddsd));
-    ddsd.dwSize = 108;
+    ddsd.dwSize = sizeof(ddsd);
 
     pDDraw->GetDisplayMode(&ddsd);
     dwRGBBitCount = ddsd.ddpfPixelFormat.dwRGBBitCount;

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -2,6 +2,9 @@
 
 #include "mxdirectdraw.h"
 
+int g_paletteIndexed8 = 0;
+BOOL DAT_10100c70 = 0;
+
 HRESULT MxDirectDraw::SetEntries()
 {
   HRESULT ret;
@@ -49,11 +52,24 @@ void MxDirectDraw::FUN_1009e830(char *error_msg, HRESULT ret)
 
 int MxDirectDraw::GetPrimaryBitDepth()
 {
+  DWORD dwRGBBitCount;
   LPDIRECTDRAW pDDraw;
+  DDSURFACEDESC ddsd;
 
-  DirectDrawCreate(NULL, &pDDraw, NULL);
+  HRESULT result = DirectDrawCreate(NULL, &pDDraw, NULL);
+  dwRGBBitCount = 0;
+  if (!result)
+  {
+    memset(&ddsd, 0, sizeof(ddsd));
+    ddsd.dwSize = 108;
 
-  return 0;
+    pDDraw->GetDisplayMode(&ddsd);
+    dwRGBBitCount = ddsd.ddpfPixelFormat.dwRGBBitCount;
+    g_paletteIndexed8 = (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) != 0;
+    pDDraw->Release();
+  }
+
+  return dwRGBBitCount;
 }
 
 int MxDirectDraw::Pause(int param_1)

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -85,7 +85,7 @@ int MxDirectDraw::Pause(int param_1)
       return 0;
     }
 
-    if (m_unk84c) {
+    if (m_fullScreen) {
       if (!FlipToGDISurface()) {
         return 0;
       }
@@ -112,7 +112,7 @@ HRESULT MxDirectDraw::FUN_1009e750()
 {
   HRESULT ret;
 
-  if (m_unk84c && m_unk848) {
+  if (m_fullScreen && m_unk848) {
     if (m_ddpal) {
       ret = m_ddpal->SetEntries(0, 0, 256, m_pal0);
       if (ret != DD_OK) {

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -2,7 +2,7 @@
 
 #include "mxdirectdraw.h"
 
-int g_paletteIndexed8 = 0;
+BOOL g_paletteIndexed8 = 0;
 BOOL DAT_10100c70 = 0;
 
 HRESULT MxDirectDraw::SetEntries()

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -24,7 +24,7 @@ private:
   PALETTEENTRY m_pal0[256]; // +0x2c
   PALETTEENTRY m_pal1[256]; // +0x42c
   HWND hWindow; // +0x83c
-  long m_unk848;
+  BOOL m_paletteIndexed8;
   BOOL m_fullScreen;
   void (*m_unk85c)(char *, HRESULT, long); // error handler or logger?
   long m_unk864;

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -25,7 +25,7 @@ private:
   PALETTEENTRY m_pal1[256]; // +0x42c
   HWND hWindow; // +0x83c
   long m_unk848;
-  long m_unk84c;
+  BOOL m_fullScreen;
   void (*m_unk85c)(char *, HRESULT, long); // error handler or logger?
   long m_unk864;
   long m_unk86c;

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -32,6 +32,4 @@ private:
 
 };
 
-BOOL DAT_10100c70 = 0;
-
 #endif // MXDIRECTDRAW_H


### PR DESCRIPTION
Adds the implementation for `GetPrimaryBitDepth`. Matches the original assembly 100%. Also named two variables.

CC https://github.com/isledecomp/isle/pull/19