### PR TITLE
Fix checkorder issues, add GH action and enforce

### DIFF
--- a/.github/workflows/order.yml
+++ b/.github/workflows/order.yml
@@ -1,0 +1,20 @@
+name: Check order
+
+on: [push, pull_request]
+
+jobs:
+  checkorder:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build isledecomp library
+      run: |
+        pip install tools/isledecomp
+
+    - name: Run checkorder.py
+      run: |
+        pip install -r tools/checkorder/requirements.txt
+        python3 tools/checkorder/checkorder.py --verbose --enforce ISLE
+        python3 tools/checkorder/checkorder.py --verbose --enforce LEGO1

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -281,9 +281,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	return msg.wParam;
 }
 
-// OFFSET: ISLE 0x401c40 TEMPLATE
-// MxDSObject::SetAtomId
-
 // OFFSET: ISLE 0x401ca0
 BOOL FindExistingInstance(void)
 {
@@ -296,6 +293,9 @@ BOOL FindExistingInstance(void)
 	}
 	return 1;
 }
+
+// OFFSET: ISLE 0x401c40 TEMPLATE
+// MxDSObject::SetAtomId
 
 // OFFSET: ISLE 0x401ce0
 BOOL StartDirectSound(void)

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -281,6 +281,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	return msg.wParam;
 }
 
+// OFFSET: ISLE 0x401c40 TEMPLATE
+// MxDSObject::SetAtomId
+
 // OFFSET: ISLE 0x401ca0
 BOOL FindExistingInstance(void)
 {

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -281,6 +281,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	return msg.wParam;
 }
 
+// OFFSET: ISLE 0x401c40 TEMPLATE
+// MxDSObject::SetAtomId
+
 // OFFSET: ISLE 0x401ca0
 BOOL FindExistingInstance(void)
 {
@@ -293,9 +296,6 @@ BOOL FindExistingInstance(void)
 	}
 	return 1;
 }
-
-// OFFSET: ISLE 0x401c40 TEMPLATE
-// MxDSObject::SetAtomId
 
 // OFFSET: ISLE 0x401ce0
 BOOL StartDirectSound(void)

--- a/LEGO1/legobuildingmanager.cpp
+++ b/LEGO1/legobuildingmanager.cpp
@@ -3,6 +3,12 @@
 // 0x100f37cc
 int g_buildingManagerConfig = 1;
 
+// OFFSET: LEGO1 0x1002f8b0
+void LegoBuildingManager::configureLegoBuildingManager(int param_1)
+{
+	g_buildingManagerConfig = param_1;
+}
+
 // OFFSET: LEGO1 0x1002f8c0
 LegoBuildingManager::LegoBuildingManager()
 {
@@ -19,10 +25,4 @@ LegoBuildingManager::~LegoBuildingManager()
 void LegoBuildingManager::Init()
 {
 	// TODO
-}
-
-// OFFSET: LEGO1 0x1002f8b0
-void LegoBuildingManager::configureLegoBuildingManager(int param_1)
-{
-	g_buildingManagerConfig = param_1;
 }

--- a/LEGO1/legocarbuild.cpp
+++ b/LEGO1/legocarbuild.cpp
@@ -12,16 +12,16 @@ LegoCarBuild::~LegoCarBuild()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x10024050 STUB
-MxLong LegoCarBuild::Notify(MxParam& p)
+// OFFSET: LEGO1 0x100238b0 STUB
+MxResult LegoCarBuild::Tickle()
 {
 	// TODO
 
 	return 0;
 }
 
-// OFFSET: LEGO1 0x100238b0 STUB
-MxResult LegoCarBuild::Tickle()
+// OFFSET: LEGO1 0x10024050 STUB
+MxLong LegoCarBuild::Notify(MxParam& p)
 {
 	// TODO
 

--- a/LEGO1/legocontrolmanager.cpp
+++ b/LEGO1/legocontrolmanager.cpp
@@ -12,14 +12,6 @@ LegoControlManager::~LegoControlManager()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x10029600 STUB
-MxResult LegoControlManager::Tickle()
-{
-	// TODO
-
-	return 0;
-}
-
 // OFFSET: LEGO1 0x10028e10 STUB
 void LegoControlManager::Register(MxCore* p_listener)
 {
@@ -30,4 +22,12 @@ void LegoControlManager::Register(MxCore* p_listener)
 void LegoControlManager::Unregister(MxCore* p_listener)
 {
 	// TODO
+}
+
+// OFFSET: LEGO1 0x10029600 STUB
+MxResult LegoControlManager::Tickle()
+{
+	// TODO
+
+	return 0;
 }

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -7,6 +7,9 @@
 
 DECOMP_SIZE_ASSERT(LegoEntity, 0x68)
 
+// OFFSET: LEGO1 0x10001090 TEMPLATE
+// LegoEntity::SetWorldSpeed
+
 // OFFSET: LEGO1 0x1000c290
 LegoEntity::~LegoEntity()
 {

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -38,15 +38,14 @@ public:
 	virtual void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2);                       // vtable+0x24
 	virtual void SetWorldTransform(Vector3Impl& p_loc, Vector3Impl& p_dir, Vector3Impl& p_up); // vtable+0x28
 	virtual void ResetWorldTransform(MxBool p_inVehicle);                                      // vtable+0x2c
-	// OFFSET: LEGO1 0x10001090
-	virtual void SetWorldSpeed(MxFloat p_worldSpeed) { m_worldSpeed = p_worldSpeed; } // vtable+0x30
-	virtual void VTable0x34();                                                        // vtable+0x34
-	virtual void VTable0x38();                                                        // vtable+0x38
-	virtual void VTable0x3c();                                                        // vtable+0x3c
-	virtual void VTable0x40();                                                        // vtable+0x40
-	virtual void VTable0x44();                                                        // vtable+0x44
-	virtual void VTable0x48();                                                        // vtable+0x48
-	virtual void VTable0x4c();                                                        // vtable+0x4c
+	virtual void SetWorldSpeed(MxFloat p_worldSpeed) { m_worldSpeed = p_worldSpeed; }          // vtable+0x30
+	virtual void VTable0x34();                                                                 // vtable+0x34
+	virtual void VTable0x38();                                                                 // vtable+0x38
+	virtual void VTable0x3c();                                                                 // vtable+0x3c
+	virtual void VTable0x40();                                                                 // vtable+0x40
+	virtual void VTable0x44();                                                                 // vtable+0x44
+	virtual void VTable0x48();                                                                 // vtable+0x48
+	virtual void VTable0x4c();                                                                 // vtable+0x4c
 
 protected:
 	void Init();

--- a/LEGO1/legogamestate.cpp
+++ b/LEGO1/legogamestate.cpp
@@ -78,42 +78,6 @@ LegoGameState::~LegoGameState()
 	delete[] m_savePath;
 }
 
-// OFFSET: LEGO1 0x10039c60 STUB
-MxResult LegoGameState::Load(MxULong)
-{
-	// TODO
-	return 0;
-}
-
-// OFFSET: LEGO1 0x1003a170
-void LegoGameState::GetFileSavePath(MxString* p_outPath, MxULong p_slotn)
-{
-	char baseForSlot[2] = "0";
-	char path[1024] = "";
-
-	// Save path base
-	if (m_savePath != NULL)
-		strcpy(path, m_savePath);
-
-	// Slot: "G0", "G1", ...
-	strcat(path, "G");
-	baseForSlot[0] += p_slotn;
-	strcat(path, baseForSlot);
-
-	// Extension: ".GS"
-	strcat(path, g_fileExtensionGS);
-	*p_outPath = MxString(path);
-}
-
-// OFFSET: LEGO1 0x1003a020
-MxResult LegoGameState::WriteEndOfVariables(LegoStream* p_stream)
-{
-	MxU8 len = strlen(s_endOfVariables);
-	if (p_stream->Write(&len, 1) == SUCCESS)
-		return p_stream->Write(s_endOfVariables, len);
-	return FAILURE;
-}
-
 // OFFSET: LEGO1 0x10039980
 MxResult LegoGameState::Save(MxULong p_slot)
 {
@@ -152,22 +116,11 @@ MxResult LegoGameState::Save(MxULong p_slot)
 	return result;
 }
 
-// OFFSET: LEGO1 0x1003a2e0 STUB
-void LegoGameState::SerializePlayersInfo(MxS16 p)
+// OFFSET: LEGO1 0x10039c60 STUB
+MxResult LegoGameState::Load(MxULong)
 {
 	// TODO
-}
-
-// OFFSET: LEGO1 0x1003cdd0 STUB
-void LegoGameState::SerializeScoreHistory(MxS16 p)
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x1003cea0
-void LegoGameState::SetSomeEnumState(undefined4 p_state)
-{
-	m_unk10 = p_state;
+	return 0;
 }
 
 // OFFSET: LEGO1 0x10039f00
@@ -182,6 +135,53 @@ void LegoGameState::SetSavePath(char* p_savePath)
 	}
 	else
 		m_savePath = NULL;
+}
+
+// OFFSET: LEGO1 0x1003a020
+MxResult LegoGameState::WriteEndOfVariables(LegoStream* p_stream)
+{
+	MxU8 len = strlen(s_endOfVariables);
+	if (p_stream->Write(&len, 1) == SUCCESS)
+		return p_stream->Write(s_endOfVariables, len);
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x1003a170
+void LegoGameState::GetFileSavePath(MxString* p_outPath, MxULong p_slotn)
+{
+	char baseForSlot[2] = "0";
+	char path[1024] = "";
+
+	// Save path base
+	if (m_savePath != NULL)
+		strcpy(path, m_savePath);
+
+	// Slot: "G0", "G1", ...
+	strcat(path, "G");
+	baseForSlot[0] += p_slotn;
+	strcat(path, baseForSlot);
+
+	// Extension: ".GS"
+	strcat(path, g_fileExtensionGS);
+	*p_outPath = MxString(path);
+}
+
+// OFFSET: LEGO1 0x1003a2e0 STUB
+void LegoGameState::SerializePlayersInfo(MxS16 p)
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x1003a720 STUB
+void LegoGameState::FUN_1003a720(MxU32 p_unk)
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x1003b060 STUB
+void LegoGameState::HandleAction(MxU32 p_unk)
+{
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1003bac0
@@ -255,14 +255,14 @@ void LegoGameState::RegisterState(LegoState* p_state)
 	m_stateArray[targetIndex] = p_state;
 }
 
-// OFFSET: LEGO1 0x1003a720 STUB
-void LegoGameState::FUN_1003a720(MxU32 p_unk)
+// OFFSET: LEGO1 0x1003cdd0 STUB
+void LegoGameState::SerializeScoreHistory(MxS16 p)
 {
 	// TODO
 }
 
-// OFFSET: LEGO1 0x1003b060 STUB
-void LegoGameState::HandleAction(MxU32 p_unk)
+// OFFSET: LEGO1 0x1003cea0
+void LegoGameState::SetSomeEnumState(undefined4 p_state)
 {
-	// TODO
+	m_unk10 = p_state;
 }

--- a/LEGO1/legonavcontroller.cpp
+++ b/LEGO1/legonavcontroller.cpp
@@ -30,62 +30,6 @@ float g_turnSensitivity = 0.4f;
 // 0x100f4c54
 MxBool g_turnUseVelocity = FALSE;
 
-// OFFSET: LEGO1 0x10054d40
-void LegoNavController::GetDefaults(
-	int* p_mouseDeadzone,
-	float* p_movementMaxSpeed,
-	float* p_turnMaxSpeed,
-	float* p_movementMaxAccel,
-	float* p_turnMaxAccel,
-	float* p_movementDecel,
-	float* p_turnDecel,
-	float* p_movementMinAccel,
-	float* p_turnMinAccel,
-	float* p_turnSensitivity,
-	MxBool* p_turnUseVelocity
-)
-{
-	*p_mouseDeadzone = g_mouseDeadzone;
-	*p_movementMaxSpeed = g_movementMaxSpeed;
-	*p_turnMaxSpeed = g_turnMaxSpeed;
-	*p_movementMaxAccel = g_movementMaxAccel;
-	*p_turnMaxAccel = g_turnMaxAccel;
-	*p_movementDecel = g_movementDecel;
-	*p_turnDecel = g_turnDecel;
-	*p_movementMinAccel = g_movementMinAccel;
-	*p_turnMinAccel = g_turnMinAccel;
-	*p_turnSensitivity = g_turnSensitivity;
-	*p_turnUseVelocity = g_turnUseVelocity;
-}
-
-// OFFSET: LEGO1 0x10054dd0
-void LegoNavController::SetDefaults(
-	int p_mouseDeadzone,
-	float p_movementMaxSpeed,
-	float p_turnMaxSpeed,
-	float p_movementMaxAccel,
-	float p_turnMaxAccel,
-	float p_movementDecel,
-	float p_turnDecel,
-	float p_movementMinAccel,
-	float p_turnMinAccel,
-	float p_turnSensitivity,
-	MxBool p_turnUseVelocity
-)
-{
-	g_mouseDeadzone = p_mouseDeadzone;
-	g_movementMaxSpeed = p_movementMaxSpeed;
-	g_turnMaxSpeed = p_turnMaxSpeed;
-	g_movementMaxAccel = p_movementMaxAccel;
-	g_turnMaxAccel = p_turnMaxAccel;
-	g_movementDecel = p_movementDecel;
-	g_turnDecel = p_turnDecel;
-	g_movementMinAccel = p_movementMinAccel;
-	g_turnMinAccel = p_turnMinAccel;
-	g_turnSensitivity = p_turnSensitivity;
-	g_turnUseVelocity = p_turnUseVelocity;
-}
-
 // OFFSET: LEGO1 0x10054ac0
 LegoNavController::LegoNavController()
 {
@@ -143,6 +87,62 @@ void LegoNavController::ResetToDefault()
 	this->m_movementMaxSpeed = g_movementMaxSpeed;
 	this->m_turnUseVelocity = g_turnUseVelocity;
 	this->m_turnSensitivity = g_turnSensitivity;
+}
+
+// OFFSET: LEGO1 0x10054d40
+void LegoNavController::GetDefaults(
+	int* p_mouseDeadzone,
+	float* p_movementMaxSpeed,
+	float* p_turnMaxSpeed,
+	float* p_movementMaxAccel,
+	float* p_turnMaxAccel,
+	float* p_movementDecel,
+	float* p_turnDecel,
+	float* p_movementMinAccel,
+	float* p_turnMinAccel,
+	float* p_turnSensitivity,
+	MxBool* p_turnUseVelocity
+)
+{
+	*p_mouseDeadzone = g_mouseDeadzone;
+	*p_movementMaxSpeed = g_movementMaxSpeed;
+	*p_turnMaxSpeed = g_turnMaxSpeed;
+	*p_movementMaxAccel = g_movementMaxAccel;
+	*p_turnMaxAccel = g_turnMaxAccel;
+	*p_movementDecel = g_movementDecel;
+	*p_turnDecel = g_turnDecel;
+	*p_movementMinAccel = g_movementMinAccel;
+	*p_turnMinAccel = g_turnMinAccel;
+	*p_turnSensitivity = g_turnSensitivity;
+	*p_turnUseVelocity = g_turnUseVelocity;
+}
+
+// OFFSET: LEGO1 0x10054dd0
+void LegoNavController::SetDefaults(
+	int p_mouseDeadzone,
+	float p_movementMaxSpeed,
+	float p_turnMaxSpeed,
+	float p_movementMaxAccel,
+	float p_turnMaxAccel,
+	float p_movementDecel,
+	float p_turnDecel,
+	float p_movementMinAccel,
+	float p_turnMinAccel,
+	float p_turnSensitivity,
+	MxBool p_turnUseVelocity
+)
+{
+	g_mouseDeadzone = p_mouseDeadzone;
+	g_movementMaxSpeed = p_movementMaxSpeed;
+	g_turnMaxSpeed = p_turnMaxSpeed;
+	g_movementMaxAccel = p_movementMaxAccel;
+	g_turnMaxAccel = p_turnMaxAccel;
+	g_movementDecel = p_movementDecel;
+	g_turnDecel = p_turnDecel;
+	g_movementMinAccel = p_movementMinAccel;
+	g_turnMinAccel = p_turnMinAccel;
+	g_turnSensitivity = p_turnSensitivity;
+	g_turnUseVelocity = p_turnUseVelocity;
 }
 
 // OFFSET: LEGO1 0x10054e40

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -109,124 +109,6 @@ const char* g_current = "current";
 // 0x101020e8
 void (*g_omniUserMessage)(const char*, int);
 
-// OFFSET: LEGO1 0x10058a00
-LegoOmni::LegoOmni()
-{
-	Init();
-}
-
-// OFFSET: LEGO1 0x10058b50
-LegoOmni::~LegoOmni()
-{
-	Destroy();
-}
-
-// OFFSET: LEGO1 0x1005b560
-void LegoOmni::CreateBackgroundAudio()
-{
-	if (m_bkgAudioManager)
-		m_bkgAudioManager->Create(*g_jukeboxScript, 100);
-}
-
-// OFFSET: LEGO1 0x1005af10 STUB
-void LegoOmni::RemoveWorld(const MxAtomId& p1, MxLong p2)
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x1005b0c0 STUB
-LegoEntity* LegoOmni::FindByEntityIdOrAtomId(const MxAtomId& p_atom, MxS32 p_entityid)
-{
-	// TODO
-	return NULL;
-}
-
-// OFFSET: LEGO1 0x1005b400 STUB
-int LegoOmni::GetCurrPathInfo(LegoPathBoundary**, int&)
-{
-	// TODO
-	return 0;
-}
-
-// OFFSET: LEGO1 0x100b6ff0
-void MakeSourceName(char* p_output, const char* p_input)
-{
-	const char* cln = strchr(p_input, ':');
-	if (cln) {
-		p_input = cln + 1;
-	}
-
-	strcpy(p_output, p_input);
-
-	strlwr(p_output);
-
-	char* extLoc = strstr(p_output, ".si");
-	if (extLoc) {
-		*extLoc = 0;
-	}
-}
-
-// OFFSET: LEGO1 0x100b7050
-MxBool KeyValueStringParse(char* p_outputValue, const char* p_key, const char* p_source)
-{
-	MxBool didMatch = FALSE;
-
-	MxS16 len = strlen(p_source);
-	char* temp = new char[len + 1];
-	strcpy(temp, p_source);
-
-	char* token = strtok(temp, ", \t\r\n:");
-	while (token) {
-		len -= (strlen(token) + 1);
-
-		if (strcmpi(token, p_key) == 0) {
-			if (p_outputValue && len > 0) {
-				char* cur = &token[strlen(p_key)];
-				cur++;
-				while (*cur != ',') {
-					if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r')
-						break;
-					*p_outputValue++ = *cur++;
-				}
-				*p_outputValue = '\0';
-			}
-
-			didMatch = TRUE;
-			break;
-		}
-
-		token = strtok(NULL, ", \t\r\n:");
-	}
-
-	delete[] temp;
-	return didMatch;
-}
-
-// OFFSET: LEGO1 0x100b7210
-void SetOmniUserMessage(void (*p_userMsg)(const char*, int))
-{
-	g_omniUserMessage = p_userMsg;
-}
-
-// OFFSET: LEGO1 0x100acf50
-MxResult Start(MxDSAction* p_dsAction)
-{
-	return MxOmni::GetInstance()->Start(p_dsAction);
-}
-
-// OFFSET: LEGO1 0x1005ad10
-LegoOmni* LegoOmni::GetInstance()
-{
-	return (LegoOmni*) MxOmni::GetInstance();
-}
-
-// OFFSET: LEGO1 0x1005ac90
-void LegoOmni::CreateInstance()
-{
-	MxOmni::DestroyInstance();
-	MxOmni::SetInstance(new LegoOmni());
-}
-
 // OFFSET: LEGO1 0x10015700
 LegoOmni* Lego()
 {
@@ -334,52 +216,10 @@ void PlayMusic(MxU32 p_index)
 	LegoOmni::GetInstance()->GetBackgroundAudioManager()->PlayMusic(action, 5, 4);
 }
 
-// OFFSET: LEGO1 0x100c0280
-MxDSObject* CreateStreamObject(MxDSFile* p_file, MxS16 p_ofs)
-{
-	char* buf;
-	_MMCKINFO tmp_chunk;
-
-	if (p_file->Seek(((MxLong*) p_file->GetBuffer())[p_ofs], 0)) {
-		return NULL;
-	}
-
-	if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
-		if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
-
-			buf = new char[tmp_chunk.cksize];
-			if (!buf) {
-				return NULL;
-			}
-
-			if (p_file->Read((MxU8*) buf, tmp_chunk.cksize) != 0) {
-				return NULL;
-			}
-
-			// Save a copy so we can clean up properly, because
-			// this function will alter the pointer value.
-			char* copy = buf;
-			MxDSObject* obj = DeserializeDSObjectDispatch(&buf, -1);
-			delete[] copy;
-			return obj;
-		}
-		return NULL;
-	}
-
-	return NULL;
-}
-
-// OFFSET: LEGO1 0x10053430
-const char* GetNoCD_SourceName()
-{
-	return g_nocdSourceName->GetInternal();
-}
-
-// OFFSET: LEGO1 0x1005b5f0 STUB
-MxLong LegoOmni::Notify(MxParam& p)
+// OFFSET: LEGO1 0x1001a700 STUB
+void FUN_1001a700()
 {
 	// TODO
-	return 0;
 }
 
 // OFFSET: LEGO1 0x1003dd70 STUB
@@ -394,180 +234,6 @@ LegoEntity* PickEntity(MxLong, MxLong)
 {
 	// TODO
 	return NULL;
-}
-
-// OFFSET: LEGO1 0x10058bd0
-void LegoOmni::Init()
-{
-	MxOmni::Init();
-	m_unk68 = 0;
-	m_inputMgr = NULL;
-	m_unk6c = 0;
-	m_gifManager = NULL;
-	m_unk78 = 0;
-	m_currentWorld = NULL;
-	m_unk80 = FALSE;
-	m_currentVehicle = NULL;
-	m_unkLegoSaveDataWriter = NULL;
-	m_plantManager = NULL;
-	m_gameState = NULL;
-	m_animationManager = NULL;
-	m_buildingManager = NULL;
-	m_bkgAudioManager = NULL;
-	m_unk13c = TRUE;
-	m_transitionManager = NULL;
-}
-
-// OFFSET: LEGO1 0x1001a700 STUB
-void FUN_1001a700()
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x10058e70
-MxResult LegoOmni::Create(MxOmniCreateParam& p)
-{
-	MxResult result = FAILURE;
-	MxAutoLocker lock(&this->m_criticalsection);
-
-	p.CreateFlags().CreateObjectFactory(FALSE);
-	p.CreateFlags().CreateVideoManager(FALSE);
-	p.CreateFlags().CreateSoundManager(FALSE);
-	p.CreateFlags().CreateTickleManager(FALSE);
-
-	if (!(m_tickleManager = new MxTickleManager()))
-		return FAILURE;
-
-	if (MxOmni::Create(p) != SUCCESS)
-		return FAILURE;
-
-	m_objectFactory = new LegoObjectFactory();
-	if (m_objectFactory == NULL)
-		return FAILURE;
-
-	if (m_soundManager = new LegoSoundManager()) {
-		if (m_soundManager->Create(10, 0) != SUCCESS) {
-			delete m_soundManager;
-			m_soundManager = NULL;
-			return FAILURE;
-		}
-	}
-
-	if (m_videoManager = new LegoVideoManager()) {
-		if (m_videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
-			delete m_videoManager;
-			m_videoManager = NULL;
-		}
-	}
-
-	if (m_inputMgr = new LegoInputManager()) {
-		if (m_inputMgr->Create(p.GetWindowHandle()) != SUCCESS) {
-			delete m_inputMgr;
-			m_inputMgr = NULL;
-		}
-	}
-
-	// TODO: there are a few more classes here
-	m_gifManager = new GifManager();
-	m_plantManager = new LegoPlantManager();
-	m_animationManager = new LegoAnimationManager();
-	m_buildingManager = new LegoBuildingManager();
-	m_gameState = new LegoGameState();
-	// TODO: initialize list at m_unk78
-
-	if (m_unk6c && m_gifManager && m_unk78 && m_plantManager && m_animationManager && m_buildingManager) {
-		// TODO: initialize a bunch of MxVariables
-		RegisterScripts();
-		FUN_1001a700();
-		// todo: another function call. in legoomni maybe?
-		m_bkgAudioManager = new MxBackgroundAudioManager();
-		if (m_bkgAudioManager != NULL) {
-			m_transitionManager = new MxTransitionManager();
-			if (m_transitionManager != NULL) {
-				if (m_transitionManager->GetDDrawSurfaceFromVideoManager() == SUCCESS) {
-					m_notificationManager->Register(this);
-					SetAppCursor(1);
-					m_gameState->SetSomeEnumState(0);
-					return SUCCESS;
-				}
-			}
-		}
-	}
-
-	return FAILURE;
-}
-
-// OFFSET: LEGO1 0x10058c30 STUB
-void LegoOmni::Destroy()
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x1005b580
-MxResult LegoOmni::Start(MxDSAction* action)
-{
-	MxResult result = MxOmni::Start(action);
-	this->m_action.SetAtomId(action->GetAtomId());
-	this->m_action.SetObjectId(action->GetObjectId());
-	this->m_action.SetUnknown24(action->GetUnknown24());
-	return result;
-}
-
-// OFFSET: LEGO1 0x1005b1d0 STUB
-MxResult LegoOmni::DeleteObject(MxDSAction& ds)
-{
-	// TODO
-	return FAILURE;
-}
-
-// OFFSET: LEGO1 0x1005b3c0
-MxBool LegoOmni::DoesEntityExist(MxDSAction& ds)
-{
-	if (MxOmni::DoesEntityExist(ds)) {
-		if (FindByEntityIdOrAtomId(ds.GetAtomId(), ds.GetObjectId()) == NULL) {
-			return TRUE;
-		}
-	}
-	return FALSE;
-}
-
-// OFFSET: LEGO1 0x1005b2f0
-MxEntity* LegoOmni::FindWorld(const char* p_id, MxS32 p_entityId, MxPresenter* p_presenter)
-{
-	LegoWorld* foundEntity = NULL;
-	if (strcmpi(p_id, g_current)) {
-		foundEntity = (LegoWorld*) FindByEntityIdOrAtomId(MxAtomId(p_id, LookupMode_LowerCase2), p_entityId);
-	}
-	else {
-		foundEntity = this->m_currentWorld;
-	}
-
-	if (foundEntity != NULL) {
-		foundEntity->VTable0x58(p_presenter);
-	}
-
-	return foundEntity;
-}
-
-// OFFSET: LEGO1 0x1005b3a0
-void LegoOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
-{
-	if (m_currentWorld)
-		NotificationManager()->Send(m_currentWorld, p_param);
-}
-
-// OFFSET: LEGO1 0x1005b640
-void LegoOmni::StartTimer()
-{
-	MxOmni::StartTimer();
-	SetAppCursor(2);
-}
-
-// OFFSET: LEGO1 0x1005b650
-void LegoOmni::StopTimer()
-{
-	MxOmni::StopTimer();
-	SetAppCursor(0);
 }
 
 // OFFSET: LEGO1 0x100528e0
@@ -664,4 +330,338 @@ void UnregisterScripts()
 	g_sndAnimScript = NULL;
 	g_creditsScript = NULL;
 	g_nocdSourceName = NULL;
+}
+
+// OFFSET: LEGO1 0x10053430
+const char* GetNoCD_SourceName()
+{
+	return g_nocdSourceName->GetInternal();
+}
+
+// OFFSET: LEGO1 0x10058a00
+LegoOmni::LegoOmni()
+{
+	Init();
+}
+
+// OFFSET: LEGO1 0x10058b50
+LegoOmni::~LegoOmni()
+{
+	Destroy();
+}
+
+// OFFSET: LEGO1 0x10058bd0
+void LegoOmni::Init()
+{
+	MxOmni::Init();
+	m_unk68 = 0;
+	m_inputMgr = NULL;
+	m_unk6c = 0;
+	m_gifManager = NULL;
+	m_unk78 = 0;
+	m_currentWorld = NULL;
+	m_unk80 = FALSE;
+	m_currentVehicle = NULL;
+	m_unkLegoSaveDataWriter = NULL;
+	m_plantManager = NULL;
+	m_gameState = NULL;
+	m_animationManager = NULL;
+	m_buildingManager = NULL;
+	m_bkgAudioManager = NULL;
+	m_unk13c = TRUE;
+	m_transitionManager = NULL;
+}
+
+// OFFSET: LEGO1 0x10058c30 STUB
+void LegoOmni::Destroy()
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x10058e70
+MxResult LegoOmni::Create(MxOmniCreateParam& p)
+{
+	MxResult result = FAILURE;
+	MxAutoLocker lock(&this->m_criticalsection);
+
+	p.CreateFlags().CreateObjectFactory(FALSE);
+	p.CreateFlags().CreateVideoManager(FALSE);
+	p.CreateFlags().CreateSoundManager(FALSE);
+	p.CreateFlags().CreateTickleManager(FALSE);
+
+	if (!(m_tickleManager = new MxTickleManager()))
+		return FAILURE;
+
+	if (MxOmni::Create(p) != SUCCESS)
+		return FAILURE;
+
+	m_objectFactory = new LegoObjectFactory();
+	if (m_objectFactory == NULL)
+		return FAILURE;
+
+	if (m_soundManager = new LegoSoundManager()) {
+		if (m_soundManager->Create(10, 0) != SUCCESS) {
+			delete m_soundManager;
+			m_soundManager = NULL;
+			return FAILURE;
+		}
+	}
+
+	if (m_videoManager = new LegoVideoManager()) {
+		if (m_videoManager->Create(p.GetVideoParam(), 100, 0) != SUCCESS) {
+			delete m_videoManager;
+			m_videoManager = NULL;
+		}
+	}
+
+	if (m_inputMgr = new LegoInputManager()) {
+		if (m_inputMgr->Create(p.GetWindowHandle()) != SUCCESS) {
+			delete m_inputMgr;
+			m_inputMgr = NULL;
+		}
+	}
+
+	// TODO: there are a few more classes here
+	m_gifManager = new GifManager();
+	m_plantManager = new LegoPlantManager();
+	m_animationManager = new LegoAnimationManager();
+	m_buildingManager = new LegoBuildingManager();
+	m_gameState = new LegoGameState();
+	// TODO: initialize list at m_unk78
+
+	if (m_unk6c && m_gifManager && m_unk78 && m_plantManager && m_animationManager && m_buildingManager) {
+		// TODO: initialize a bunch of MxVariables
+		RegisterScripts();
+		FUN_1001a700();
+		// todo: another function call. in legoomni maybe?
+		m_bkgAudioManager = new MxBackgroundAudioManager();
+		if (m_bkgAudioManager != NULL) {
+			m_transitionManager = new MxTransitionManager();
+			if (m_transitionManager != NULL) {
+				if (m_transitionManager->GetDDrawSurfaceFromVideoManager() == SUCCESS) {
+					m_notificationManager->Register(this);
+					SetAppCursor(1);
+					m_gameState->SetSomeEnumState(0);
+					return SUCCESS;
+				}
+			}
+		}
+	}
+
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x1005ac90
+void LegoOmni::CreateInstance()
+{
+	MxOmni::DestroyInstance();
+	MxOmni::SetInstance(new LegoOmni());
+}
+
+// OFFSET: LEGO1 0x1005ad10
+LegoOmni* LegoOmni::GetInstance()
+{
+	return (LegoOmni*) MxOmni::GetInstance();
+}
+
+// OFFSET: LEGO1 0x1005af10 STUB
+void LegoOmni::RemoveWorld(const MxAtomId& p1, MxLong p2)
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x1005b0c0 STUB
+LegoEntity* LegoOmni::FindByEntityIdOrAtomId(const MxAtomId& p_atom, MxS32 p_entityid)
+{
+	// TODO
+	return NULL;
+}
+
+// OFFSET: LEGO1 0x1005b1d0 STUB
+MxResult LegoOmni::DeleteObject(MxDSAction& ds)
+{
+	// TODO
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x1005b2f0
+MxEntity* LegoOmni::FindWorld(const char* p_id, MxS32 p_entityId, MxPresenter* p_presenter)
+{
+	LegoWorld* foundEntity = NULL;
+	if (strcmpi(p_id, g_current)) {
+		foundEntity = (LegoWorld*) FindByEntityIdOrAtomId(MxAtomId(p_id, LookupMode_LowerCase2), p_entityId);
+	}
+	else {
+		foundEntity = this->m_currentWorld;
+	}
+
+	if (foundEntity != NULL) {
+		foundEntity->VTable0x58(p_presenter);
+	}
+
+	return foundEntity;
+}
+
+// OFFSET: LEGO1 0x1005b3a0
+void LegoOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
+{
+	if (m_currentWorld)
+		NotificationManager()->Send(m_currentWorld, p_param);
+}
+
+// OFFSET: LEGO1 0x1005b3c0
+MxBool LegoOmni::DoesEntityExist(MxDSAction& ds)
+{
+	if (MxOmni::DoesEntityExist(ds)) {
+		if (FindByEntityIdOrAtomId(ds.GetAtomId(), ds.GetObjectId()) == NULL) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+// OFFSET: LEGO1 0x1005b400 STUB
+int LegoOmni::GetCurrPathInfo(LegoPathBoundary**, int&)
+{
+	// TODO
+	return 0;
+}
+
+// OFFSET: LEGO1 0x1005b560
+void LegoOmni::CreateBackgroundAudio()
+{
+	if (m_bkgAudioManager)
+		m_bkgAudioManager->Create(*g_jukeboxScript, 100);
+}
+
+// OFFSET: LEGO1 0x1005b580
+MxResult LegoOmni::Start(MxDSAction* action)
+{
+	MxResult result = MxOmni::Start(action);
+	this->m_action.SetAtomId(action->GetAtomId());
+	this->m_action.SetObjectId(action->GetObjectId());
+	this->m_action.SetUnknown24(action->GetUnknown24());
+	return result;
+}
+
+// OFFSET: LEGO1 0x1005b5f0 STUB
+MxLong LegoOmni::Notify(MxParam& p)
+{
+	// TODO
+	return 0;
+}
+
+// OFFSET: LEGO1 0x1005b640
+void LegoOmni::StartTimer()
+{
+	MxOmni::StartTimer();
+	SetAppCursor(2);
+}
+
+// OFFSET: LEGO1 0x1005b650
+void LegoOmni::StopTimer()
+{
+	MxOmni::StopTimer();
+	SetAppCursor(0);
+}
+
+// OFFSET: LEGO1 0x100acf50
+MxResult Start(MxDSAction* p_dsAction)
+{
+	return MxOmni::GetInstance()->Start(p_dsAction);
+}
+
+// OFFSET: LEGO1 0x100b6ff0
+void MakeSourceName(char* p_output, const char* p_input)
+{
+	const char* cln = strchr(p_input, ':');
+	if (cln) {
+		p_input = cln + 1;
+	}
+
+	strcpy(p_output, p_input);
+
+	strlwr(p_output);
+
+	char* extLoc = strstr(p_output, ".si");
+	if (extLoc) {
+		*extLoc = 0;
+	}
+}
+
+// OFFSET: LEGO1 0x100b7050
+MxBool KeyValueStringParse(char* p_outputValue, const char* p_key, const char* p_source)
+{
+	MxBool didMatch = FALSE;
+
+	MxS16 len = strlen(p_source);
+	char* temp = new char[len + 1];
+	strcpy(temp, p_source);
+
+	char* token = strtok(temp, ", \t\r\n:");
+	while (token) {
+		len -= (strlen(token) + 1);
+
+		if (strcmpi(token, p_key) == 0) {
+			if (p_outputValue && len > 0) {
+				char* cur = &token[strlen(p_key)];
+				cur++;
+				while (*cur != ',') {
+					if (*cur == ' ' || *cur == '\0' || *cur == '\t' || *cur == '\n' || *cur == '\r')
+						break;
+					*p_outputValue++ = *cur++;
+				}
+				*p_outputValue = '\0';
+			}
+
+			didMatch = TRUE;
+			break;
+		}
+
+		token = strtok(NULL, ", \t\r\n:");
+	}
+
+	delete[] temp;
+	return didMatch;
+}
+
+// OFFSET: LEGO1 0x100b7210
+void SetOmniUserMessage(void (*p_userMsg)(const char*, int))
+{
+	g_omniUserMessage = p_userMsg;
+}
+
+// OFFSET: LEGO1 0x100c0280
+MxDSObject* CreateStreamObject(MxDSFile* p_file, MxS16 p_ofs)
+{
+	char* buf;
+	_MMCKINFO tmp_chunk;
+
+	if (p_file->Seek(((MxLong*) p_file->GetBuffer())[p_ofs], 0)) {
+		return NULL;
+	}
+
+	if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'S', 't')) {
+		if (p_file->Read((MxU8*) &tmp_chunk.ckid, 8) == 0 && tmp_chunk.ckid == FOURCC('M', 'x', 'O', 'b')) {
+
+			buf = new char[tmp_chunk.cksize];
+			if (!buf) {
+				return NULL;
+			}
+
+			if (p_file->Read((MxU8*) buf, tmp_chunk.cksize) != 0) {
+				return NULL;
+			}
+
+			// Save a copy so we can clean up properly, because
+			// this function will alter the pointer value.
+			char* copy = buf;
+			MxDSObject* obj = DeserializeDSObjectDispatch(&buf, -1);
+			delete[] copy;
+			return obj;
+		}
+		return NULL;
+	}
+
+	return NULL;
 }

--- a/LEGO1/legophonemepresenter.cpp
+++ b/LEGO1/legophonemepresenter.cpp
@@ -8,6 +8,11 @@ LegoPhonemePresenter::LegoPhonemePresenter()
 	Init();
 }
 
+// OFFSET: LEGO1 0x1004e340
+LegoPhonemePresenter::~LegoPhonemePresenter()
+{
+}
+
 // OFFSET: LEGO1 0x1004e3b0
 void LegoPhonemePresenter::Init()
 {
@@ -15,9 +20,4 @@ void LegoPhonemePresenter::Init()
 	m_unk6c = 0;
 	m_unk70 = 0;
 	m_unk84 = 0;
-}
-
-// OFFSET: LEGO1 0x1004e340
-LegoPhonemePresenter::~LegoPhonemePresenter()
-{
 }

--- a/LEGO1/legoplantmanager.cpp
+++ b/LEGO1/legoplantmanager.cpp
@@ -12,16 +12,16 @@ LegoPlantManager::~LegoPlantManager()
 	// TODO
 }
 
+// OFFSET: LEGO1 0x10026330 STUB
+void LegoPlantManager::Init()
+{
+	// TODO
+}
+
 // OFFSET: LEGO1 0x10026e00 STUB
 MxResult LegoPlantManager::Tickle()
 {
 	// TODO
 
 	return 0;
-}
-
-// OFFSET: LEGO1 0x10026330 STUB
-void LegoPlantManager::Init()
-{
-	// TODO
 }

--- a/LEGO1/legosoundmanager.cpp
+++ b/LEGO1/legosoundmanager.cpp
@@ -14,10 +14,11 @@ LegoSoundManager::~LegoSoundManager()
 	Destroy(TRUE);
 }
 
-// OFFSET: LEGO1 0x1002a390
-void LegoSoundManager::Destroy()
+// OFFSET: LEGO1 0x100299a0
+void LegoSoundManager::Init()
 {
-	Destroy(FALSE);
+	unk0x40 = 0;
+	unk0x3c = 0;
 }
 
 // OFFSET: LEGO1 0x100299b0 STUB
@@ -31,11 +32,10 @@ MxResult LegoSoundManager::Create(MxU32 p_frequencyMS, MxBool p_createThread)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100299a0
-void LegoSoundManager::Init()
+// OFFSET: LEGO1 0x1002a390
+void LegoSoundManager::Destroy()
 {
-	unk0x40 = 0;
-	unk0x3c = 0;
+	Destroy(FALSE);
 }
 
 // OFFSET: LEGO1 0x1002a3a0 STUB

--- a/LEGO1/legostream.cpp
+++ b/LEGO1/legostream.cpp
@@ -19,6 +19,55 @@ DECOMP_SIZE_ASSERT(LegoStream, 0x8);
 DECOMP_SIZE_ASSERT(LegoFileStream, 0xC);
 DECOMP_SIZE_ASSERT(LegoMemoryStream, 0x10);
 
+// OFFSET: LEGO1 0x10039f70
+MxResult LegoStream::WriteVariable(LegoStream* p_stream, MxVariableTable* p_from, const char* p_variableName)
+{
+	MxResult result = FAILURE;
+	const char* variableValue = p_from->GetVariable(p_variableName);
+
+	if (variableValue) {
+		MxU8 length = strlen(p_variableName);
+		if (p_stream->Write((char*) &length, 1) == SUCCESS) {
+			if (p_stream->Write(p_variableName, length) == SUCCESS) {
+				length = strlen(variableValue);
+				if (p_stream->Write((char*) &length, 1) == SUCCESS)
+					result = p_stream->Write((char*) variableValue, length);
+			}
+		}
+	}
+	return result;
+}
+
+// 95% match, just some instruction ordering differences on the call to
+// MxVariableTable::SetVariable at the end.
+// OFFSET: LEGO1 0x1003a080
+MxS32 LegoStream::ReadVariable(LegoStream* p_stream, MxVariableTable* p_to)
+{
+	MxS32 result = 1;
+	MxU8 length;
+
+	if (p_stream->Read((char*) &length, 1) == SUCCESS) {
+		char nameBuffer[256];
+		if (p_stream->Read(nameBuffer, length) == SUCCESS) {
+			nameBuffer[length] = '\0';
+			if (strcmp(nameBuffer, s_endOfVariables) == 0)
+				// 2 -> "This was the last entry, done reading."
+				result = 2;
+			else {
+				if (p_stream->Read((char*) &length, 1) == SUCCESS) {
+					char valueBuffer[256];
+					if (p_stream->Read(valueBuffer, length) == SUCCESS) {
+						result = 0;
+						valueBuffer[length] = '\0';
+						p_to->SetVariable(nameBuffer, valueBuffer);
+					}
+				}
+			}
+		}
+	}
+	return result;
+}
+
 // OFFSET: LEGO1 0x10045ae0
 MxBool LegoStream::IsWriteMode()
 {
@@ -29,6 +78,29 @@ MxBool LegoStream::IsWriteMode()
 MxBool LegoStream::IsReadMode()
 {
 	return m_mode == LEGOSTREAM_MODE_READ;
+}
+
+// OFFSET: LEGO1 0x10099080
+LegoMemoryStream::LegoMemoryStream(char* p_buffer) : LegoStream()
+{
+	m_buffer = p_buffer;
+	m_offset = 0;
+}
+
+// OFFSET: LEGO1 0x10099160
+MxResult LegoMemoryStream::Read(void* p_buffer, MxU32 p_size)
+{
+	memcpy(p_buffer, m_buffer + m_offset, p_size);
+	m_offset += p_size;
+	return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x10099190
+MxResult LegoMemoryStream::Write(const void* p_buffer, MxU32 p_size)
+{
+	memcpy(m_buffer + m_offset, p_buffer, p_size);
+	m_offset += p_size;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100991c0
@@ -113,29 +185,6 @@ MxResult LegoFileStream::Open(const char* p_filename, OpenFlags p_mode)
 	return (m_hFile = fopen(p_filename, modeString)) ? SUCCESS : FAILURE;
 }
 
-// OFFSET: LEGO1 0x10099080
-LegoMemoryStream::LegoMemoryStream(char* p_buffer) : LegoStream()
-{
-	m_buffer = p_buffer;
-	m_offset = 0;
-}
-
-// OFFSET: LEGO1 0x10099160
-MxResult LegoMemoryStream::Read(void* p_buffer, MxU32 p_size)
-{
-	memcpy(p_buffer, m_buffer + m_offset, p_size);
-	m_offset += p_size;
-	return SUCCESS;
-}
-
-// OFFSET: LEGO1 0x10099190
-MxResult LegoMemoryStream::Write(const void* p_buffer, MxU32 p_size)
-{
-	memcpy(m_buffer + m_offset, p_buffer, p_size);
-	m_offset += p_size;
-	return SUCCESS;
-}
-
 // OFFSET: LEGO1 0x100994a0
 MxResult LegoMemoryStream::Tell(MxU32* p_offset)
 {
@@ -148,53 +197,4 @@ MxResult LegoMemoryStream::Seek(MxU32 p_offset)
 {
 	m_offset = p_offset;
 	return SUCCESS;
-}
-
-// OFFSET: LEGO1 0x10039f70
-MxResult LegoStream::WriteVariable(LegoStream* p_stream, MxVariableTable* p_from, const char* p_variableName)
-{
-	MxResult result = FAILURE;
-	const char* variableValue = p_from->GetVariable(p_variableName);
-
-	if (variableValue) {
-		MxU8 length = strlen(p_variableName);
-		if (p_stream->Write((char*) &length, 1) == SUCCESS) {
-			if (p_stream->Write(p_variableName, length) == SUCCESS) {
-				length = strlen(variableValue);
-				if (p_stream->Write((char*) &length, 1) == SUCCESS)
-					result = p_stream->Write((char*) variableValue, length);
-			}
-		}
-	}
-	return result;
-}
-
-// 95% match, just some instruction ordering differences on the call to
-// MxVariableTable::SetVariable at the end.
-// OFFSET: LEGO1 0x1003a080
-MxS32 LegoStream::ReadVariable(LegoStream* p_stream, MxVariableTable* p_to)
-{
-	MxS32 result = 1;
-	MxU8 length;
-
-	if (p_stream->Read((char*) &length, 1) == SUCCESS) {
-		char nameBuffer[256];
-		if (p_stream->Read(nameBuffer, length) == SUCCESS) {
-			nameBuffer[length] = '\0';
-			if (strcmp(nameBuffer, s_endOfVariables) == 0)
-				// 2 -> "This was the last entry, done reading."
-				result = 2;
-			else {
-				if (p_stream->Read((char*) &length, 1) == SUCCESS) {
-					char valueBuffer[256];
-					if (p_stream->Read(valueBuffer, length) == SUCCESS) {
-						result = 0;
-						valueBuffer[length] = '\0';
-						p_to->SetVariable(nameBuffer, valueBuffer);
-					}
-				}
-			}
-		}
-	}
-	return result;
 }

--- a/LEGO1/legovehiclebuildstate.cpp
+++ b/LEGO1/legovehiclebuildstate.cpp
@@ -5,6 +5,15 @@
 DECOMP_SIZE_ASSERT(LegoVehicleBuildState, 0x50); // 1000acd7
 DECOMP_SIZE_ASSERT(LegoVehicleBuildState::UnkStruct, 0xc);
 
+// OFFSET: LEGO1 0x10017c00
+LegoVehicleBuildState::UnkStruct::UnkStruct()
+{
+	m_unk04 = 0;
+	m_unk00 = 0;
+	m_unk06 = 0;
+	m_unk08 = 0;
+}
+
 // OFFSET: LEGO1 0x10025f30
 LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 {
@@ -13,13 +22,4 @@ LegoVehicleBuildState::LegoVehicleBuildState(char* p_classType)
 	this->m_unk4d = 0;
 	this->m_unk4e = 0;
 	this->m_placedPartCount = 0;
-}
-
-// OFFSET: LEGO1 10017c00
-LegoVehicleBuildState::UnkStruct::UnkStruct()
-{
-	m_unk04 = 0;
-	m_unk00 = 0;
-	m_unk06 = 0;
-	m_unk08 = 0;
 }

--- a/LEGO1/legovideomanager.cpp
+++ b/LEGO1/legovideomanager.cpp
@@ -55,32 +55,6 @@ void LegoVideoManager::Destroy()
 	delete[] m_prefCounter;
 }
 
-// OFFSET: LEGO1 0x1007c560 STUB
-int LegoVideoManager::EnableRMDevice()
-{
-	// TODO
-	return 0;
-}
-
-// OFFSET: LEGO1 0x1007c740 STUB
-int LegoVideoManager::DisableRMDevice()
-{
-	// TODO
-	return 0;
-}
-
-// OFFSET: LEGO1 0x1007c300
-void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable)
-{
-	EnableFullScreenMovie(p_enable, TRUE);
-}
-
-// OFFSET: LEGO1 0x1007c310 STUB
-void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable, MxBool p_scale)
-{
-	// TODO
-}
-
 // OFFSET: LEGO1 0x1007b6a0
 void LegoVideoManager::MoveCursor(MxS32 p_cursorX, MxS32 p_cursorY)
 {
@@ -93,6 +67,18 @@ void LegoVideoManager::MoveCursor(MxS32 p_cursorX, MxS32 p_cursorY)
 
 	if (463 < p_cursorY)
 		m_cursorY = 463;
+}
+
+// OFFSET: LEGO1 0x1007c300
+void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable)
+{
+	EnableFullScreenMovie(p_enable, TRUE);
+}
+
+// OFFSET: LEGO1 0x1007c310 STUB
+void LegoVideoManager::EnableFullScreenMovie(MxBool p_enable, MxBool p_scale)
+{
+	// TODO
 }
 
 // OFFSET: LEGO1 0x1007c440
@@ -109,4 +95,18 @@ void LegoVideoManager::SetSkyColor(float p_red, float p_green, float p_blue)
 
 	// TODO 3d manager
 	// m_3dManager->m_pViewport->vtable1c(red, green, blue)
+}
+
+// OFFSET: LEGO1 0x1007c560 STUB
+int LegoVideoManager::EnableRMDevice()
+{
+	// TODO
+	return 0;
+}
+
+// OFFSET: LEGO1 0x1007c740 STUB
+int LegoVideoManager::DisableRMDevice()
+{
+	// TODO
+	return 0;
 }

--- a/LEGO1/legoworld.cpp
+++ b/LEGO1/legoworld.cpp
@@ -16,10 +16,42 @@ void LegoWorld::VTable0x60()
 {
 }
 
+// OFFSET: LEGO1 0x10015820 STUB
+void FUN_10015820(MxU32 p_unk1, MxU32 p_unk2)
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x10015910 STUB
+void FUN_10015910(MxU32 p_unk1)
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x100159c0
+void SetIsWorldActive(MxBool p_isWorldActive)
+{
+	if (!p_isWorldActive)
+		LegoOmni::GetInstance()->GetInputManager()->SetCamera(NULL);
+	g_isWorldActive = p_isWorldActive;
+}
+
 // OFFSET: LEGO1 0x1001ca40 STUB
 LegoWorld::LegoWorld()
 {
 	// TODO
+}
+
+// OFFSET: LEGO1 0x1001d670
+MxBool LegoWorld::VTable0x5c()
+{
+	return FALSE;
+}
+
+// OFFSET: LEGO1 0x1001d680
+MxBool LegoWorld::VTable0x64()
+{
+	return FALSE;
 }
 
 // OFFSET: LEGO1 0x1001dfa0 STUB
@@ -28,10 +60,11 @@ LegoWorld::~LegoWorld()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x10022340
-void LegoWorld::Stop()
+// OFFSET: LEGO1 0x1001e0b0 STUB
+MxResult LegoWorld::SetAsCurrentWorld(MxDSObject& p_dsObject)
 {
-	TickleManager()->UnregisterClient(this);
+	// TODO
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1001f5e0
@@ -58,27 +91,15 @@ void LegoWorld::VTable0x54()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x10020f10 STUB
-void LegoWorld::EndAction(MxPresenter* p_presenter)
-{
-}
-
 // OFFSET: LEGO1 0x10020220 STUB
 void LegoWorld::VTable0x58(MxCore* p_object)
 {
 	// TODO
 }
 
-// OFFSET: LEGO1 0x1001d670
-MxBool LegoWorld::VTable0x5c()
+// OFFSET: LEGO1 0x10020f10 STUB
+void LegoWorld::EndAction(MxPresenter* p_presenter)
 {
-	return FALSE;
-}
-
-// OFFSET: LEGO1 0x1001d680
-MxBool LegoWorld::VTable0x64()
-{
-	return FALSE;
 }
 
 // OFFSET: LEGO1 0x10021a70 STUB
@@ -87,29 +108,8 @@ void LegoWorld::VTable0x68(MxBool p_add)
 	// TODO
 }
 
-// OFFSET: LEGO1 0x1001e0b0 STUB
-MxResult LegoWorld::SetAsCurrentWorld(MxDSObject& p_dsObject)
+// OFFSET: LEGO1 0x10022340
+void LegoWorld::Stop()
 {
-	// TODO
-	return SUCCESS;
-}
-
-// OFFSET: LEGO1 0x10015820 STUB
-void FUN_10015820(MxU32 p_unk1, MxU32 p_unk2)
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x10015910 STUB
-void FUN_10015910(MxU32 p_unk1)
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x100159c0
-void SetIsWorldActive(MxBool p_isWorldActive)
-{
-	if (!p_isWorldActive)
-		LegoOmni::GetInstance()->GetInputManager()->SetCamera(NULL);
-	g_isWorldActive = p_isWorldActive;
+	TickleManager()->UnregisterClient(this);
 }

--- a/LEGO1/legoworldpresenter.cpp
+++ b/LEGO1/legoworldpresenter.cpp
@@ -3,6 +3,12 @@
 // 0x100f75d4
 undefined4 g_LegoWorldPresenterQuality = 1;
 
+// OFFSET: LEGO1 0x100665b0
+void LegoWorldPresenter::configureLegoWorldPresenter(int p_quality)
+{
+	g_LegoWorldPresenterQuality = p_quality;
+}
+
 // OFFSET: LEGO1 0x100665c0
 LegoWorldPresenter::LegoWorldPresenter()
 {
@@ -13,10 +19,4 @@ LegoWorldPresenter::LegoWorldPresenter()
 LegoWorldPresenter::~LegoWorldPresenter()
 {
 	// TODO
-}
-
-// OFFSET: LEGO1 0x100665b0
-void LegoWorldPresenter::configureLegoWorldPresenter(int p_quality)
-{
-	g_LegoWorldPresenterQuality = p_quality;
 }

--- a/LEGO1/mxaudiomanager.cpp
+++ b/LEGO1/mxaudiomanager.cpp
@@ -5,6 +5,12 @@ DECOMP_SIZE_ASSERT(MxAudioManager, 0x30);
 // GLOBAL: LEGO1 0x10102108
 MxS32 MxAudioManager::g_unkCount = 0;
 
+// OFFSET: LEGO1 0x10029910
+MxS32 MxAudioManager::GetVolume()
+{
+	return this->m_volume;
+}
+
 // OFFSET: LEGO1 0x100b8d00
 MxAudioManager::MxAudioManager()
 {
@@ -21,20 +27,6 @@ MxAudioManager::~MxAudioManager()
 void MxAudioManager::Init()
 {
 	this->m_volume = 100;
-}
-
-// OFFSET: LEGO1 0x10029910
-MxS32 MxAudioManager::GetVolume()
-{
-	return this->m_volume;
-}
-
-// OFFSET: LEGO1 0x100b8ea0
-void MxAudioManager::SetVolume(MxS32 p_volume)
-{
-	this->m_criticalSection.Enter();
-	this->m_volume = p_volume;
-	this->m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100b8e00
@@ -75,4 +67,12 @@ MxResult MxAudioManager::InitPresenters()
 void MxAudioManager::Destroy()
 {
 	Destroy(FALSE);
+}
+
+// OFFSET: LEGO1 0x100b8ea0
+void MxAudioManager::SetVolume(MxS32 p_volume)
+{
+	this->m_criticalSection.Enter();
+	this->m_volume = p_volume;
+	this->m_criticalSection.Leave();
 }

--- a/LEGO1/mxbackgroundaudiomanager.cpp
+++ b/LEGO1/mxbackgroundaudiomanager.cpp
@@ -31,70 +31,6 @@ MxBackgroundAudioManager::~MxBackgroundAudioManager()
 	DestroyMusic();
 }
 
-// OFFSET: LEGO1 0x1007f470
-void MxBackgroundAudioManager::Stop()
-{
-	if (m_action2.GetObjectId() != -1)
-		DeleteObject(m_action2);
-
-	m_unk138 = 0;
-	m_action2.SetAtomId(MxAtomId());
-	m_action2.SetObjectId(-1);
-
-	if (m_action1.GetObjectId() != -1)
-		DeleteObject(m_action1);
-
-	m_unka0 = 0;
-	m_action1.SetAtomId(MxAtomId());
-	m_unk148 = 0;
-	m_action1.SetObjectId(-1);
-	m_unk13c = 0;
-}
-
-// OFFSET: LEGO1 0x1007f570
-void MxBackgroundAudioManager::LowerVolume()
-{
-	if (m_unk148 == 0) {
-		if (m_unk13c == 0) {
-			m_unk13c = 2;
-		}
-		m_unk140 = 20;
-	}
-	m_unk148++;
-}
-
-// OFFSET: LEGO1 0x1007f5b0
-void MxBackgroundAudioManager::RaiseVolume()
-{
-	if (m_unk148 != 0) {
-		m_unk148--;
-		if (m_unk148 == 0) {
-			if (m_unk13c == 0) {
-				m_unk13c = 2;
-			}
-			m_unk140 = 10;
-		}
-	}
-}
-
-// OFFSET: LEGO1 0x1007f5f0
-void MxBackgroundAudioManager::Enable(MxBool p)
-{
-	if (this->m_musicEnabled != p) {
-		this->m_musicEnabled = p;
-		if (!p) {
-			Stop();
-		}
-	}
-}
-
-// OFFSET: LEGO1 0x1007f650
-void MxBackgroundAudioManager::Init()
-{
-	this->m_unka0 = 0;
-	this->m_unk13c = 0;
-}
-
 // OFFSET: LEGO1 0x1007ece0
 MxResult MxBackgroundAudioManager::Create(MxAtomId& p_script, MxU32 p_frequencyMS)
 {
@@ -135,80 +71,6 @@ void MxBackgroundAudioManager::DestroyMusic()
 		Streamer()->Close(m_script.GetInternal());
 		m_musicEnabled = FALSE;
 	}
-}
-
-// OFFSET: LEGO1 0x1007f170
-MxLong MxBackgroundAudioManager::Notify(MxParam& p)
-{
-	switch (((MxNotificationParam&) p).GetNotification()) {
-	case c_notificationStartAction:
-		StartAction(p);
-		return 1;
-	case c_notificationEndAction:
-		StopAction(p);
-		return 1;
-	}
-	return 0;
-}
-
-// OFFSET: LEGO1 0x1007f1b0
-void MxBackgroundAudioManager::StartAction(MxParam& p)
-{
-	// TODO: the sender is most likely a MxAudioPresenter?
-	m_unk138 = (MxAudioPresenter*) ((MxNotificationParam&) p).GetSender();
-	m_action2.SetAtomId(m_unk138->GetAction()->GetAtomId());
-	m_action2.SetObjectId(m_unk138->GetAction()->GetObjectId());
-	m_targetVolume = ((MxDSSound*) (m_unk138->GetAction()))->GetVolume();
-	m_unk138->SetVolume(0);
-}
-
-// OFFSET: LEGO1 0x1007f200
-void MxBackgroundAudioManager::StopAction(MxParam& p)
-{
-	if (((MxNotificationParam&) p).GetSender() == m_unka0) {
-		m_unka0 = NULL;
-		m_action1.SetAtomId(MxAtomId());
-		m_action1.SetObjectId(-1);
-	}
-	else if (((MxNotificationParam&) p).GetSender() == m_unk138) {
-		m_unk138 = NULL;
-		m_action2.SetAtomId(MxAtomId());
-		m_action2.SetObjectId(-1);
-	}
-
-	Lego()->HandleNotificationType2(p);
-}
-
-// OFFSET: LEGO1 0x1007f2f0
-MxResult MxBackgroundAudioManager::PlayMusic(MxDSAction& p_action, undefined4 p_unknown, undefined4 p_unknown2)
-{
-	if (!m_musicEnabled) {
-		return SUCCESS;
-	}
-	if (m_action2.GetObjectId() == -1 && m_action1.GetObjectId() != p_action.GetObjectId()) {
-		MxDSAction action;
-		action.SetAtomId(GetCurrentAction().GetAtomId());
-		action.SetObjectId(GetCurrentAction().GetObjectId());
-		action.SetUnknown24(GetCurrentAction().GetUnknown24());
-
-		m_action2.SetAtomId(p_action.GetAtomId());
-		m_action2.SetObjectId(p_action.GetObjectId());
-		m_action2.SetUnknown84(this);
-		m_action2.SetUnknown8c(this);
-
-		MxResult result = Start(&m_action2);
-
-		GetCurrentAction().SetAtomId(action.GetAtomId());
-		GetCurrentAction().SetObjectId(action.GetObjectId());
-		GetCurrentAction().SetUnknown24(action.GetUnknown24());
-
-		if (result == SUCCESS) {
-			m_unk13c = p_unknown2;
-			m_unk140 = p_unknown;
-		}
-		return result;
-	}
-	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x1007ee40
@@ -323,4 +185,142 @@ void MxBackgroundAudioManager::FadeInOrFadeOut()
 	else {
 		m_unk13c = 0;
 	}
+}
+
+// OFFSET: LEGO1 0x1007f170
+MxLong MxBackgroundAudioManager::Notify(MxParam& p)
+{
+	switch (((MxNotificationParam&) p).GetNotification()) {
+	case c_notificationStartAction:
+		StartAction(p);
+		return 1;
+	case c_notificationEndAction:
+		StopAction(p);
+		return 1;
+	}
+	return 0;
+}
+
+// OFFSET: LEGO1 0x1007f1b0
+void MxBackgroundAudioManager::StartAction(MxParam& p)
+{
+	// TODO: the sender is most likely a MxAudioPresenter?
+	m_unk138 = (MxAudioPresenter*) ((MxNotificationParam&) p).GetSender();
+	m_action2.SetAtomId(m_unk138->GetAction()->GetAtomId());
+	m_action2.SetObjectId(m_unk138->GetAction()->GetObjectId());
+	m_targetVolume = ((MxDSSound*) (m_unk138->GetAction()))->GetVolume();
+	m_unk138->SetVolume(0);
+}
+
+// OFFSET: LEGO1 0x1007f200
+void MxBackgroundAudioManager::StopAction(MxParam& p)
+{
+	if (((MxNotificationParam&) p).GetSender() == m_unka0) {
+		m_unka0 = NULL;
+		m_action1.SetAtomId(MxAtomId());
+		m_action1.SetObjectId(-1);
+	}
+	else if (((MxNotificationParam&) p).GetSender() == m_unk138) {
+		m_unk138 = NULL;
+		m_action2.SetAtomId(MxAtomId());
+		m_action2.SetObjectId(-1);
+	}
+
+	Lego()->HandleNotificationType2(p);
+}
+
+// OFFSET: LEGO1 0x1007f2f0
+MxResult MxBackgroundAudioManager::PlayMusic(MxDSAction& p_action, undefined4 p_unknown, undefined4 p_unknown2)
+{
+	if (!m_musicEnabled) {
+		return SUCCESS;
+	}
+	if (m_action2.GetObjectId() == -1 && m_action1.GetObjectId() != p_action.GetObjectId()) {
+		MxDSAction action;
+		action.SetAtomId(GetCurrentAction().GetAtomId());
+		action.SetObjectId(GetCurrentAction().GetObjectId());
+		action.SetUnknown24(GetCurrentAction().GetUnknown24());
+
+		m_action2.SetAtomId(p_action.GetAtomId());
+		m_action2.SetObjectId(p_action.GetObjectId());
+		m_action2.SetUnknown84(this);
+		m_action2.SetUnknown8c(this);
+
+		MxResult result = Start(&m_action2);
+
+		GetCurrentAction().SetAtomId(action.GetAtomId());
+		GetCurrentAction().SetObjectId(action.GetObjectId());
+		GetCurrentAction().SetUnknown24(action.GetUnknown24());
+
+		if (result == SUCCESS) {
+			m_unk13c = p_unknown2;
+			m_unk140 = p_unknown;
+		}
+		return result;
+	}
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x1007f470
+void MxBackgroundAudioManager::Stop()
+{
+	if (m_action2.GetObjectId() != -1)
+		DeleteObject(m_action2);
+
+	m_unk138 = 0;
+	m_action2.SetAtomId(MxAtomId());
+	m_action2.SetObjectId(-1);
+
+	if (m_action1.GetObjectId() != -1)
+		DeleteObject(m_action1);
+
+	m_unka0 = 0;
+	m_action1.SetAtomId(MxAtomId());
+	m_unk148 = 0;
+	m_action1.SetObjectId(-1);
+	m_unk13c = 0;
+}
+
+// OFFSET: LEGO1 0x1007f570
+void MxBackgroundAudioManager::LowerVolume()
+{
+	if (m_unk148 == 0) {
+		if (m_unk13c == 0) {
+			m_unk13c = 2;
+		}
+		m_unk140 = 20;
+	}
+	m_unk148++;
+}
+
+// OFFSET: LEGO1 0x1007f5b0
+void MxBackgroundAudioManager::RaiseVolume()
+{
+	if (m_unk148 != 0) {
+		m_unk148--;
+		if (m_unk148 == 0) {
+			if (m_unk13c == 0) {
+				m_unk13c = 2;
+			}
+			m_unk140 = 10;
+		}
+	}
+}
+
+// OFFSET: LEGO1 0x1007f5f0
+void MxBackgroundAudioManager::Enable(MxBool p)
+{
+	if (this->m_musicEnabled != p) {
+		this->m_musicEnabled = p;
+		if (!p) {
+			Stop();
+		}
+	}
+}
+
+// OFFSET: LEGO1 0x1007f650
+void MxBackgroundAudioManager::Init()
+{
+	this->m_unka0 = 0;
+	this->m_unk13c = 0;
 }

--- a/LEGO1/mxcompositepresenter.cpp
+++ b/LEGO1/mxcompositepresenter.cpp
@@ -5,6 +5,14 @@
 
 DECOMP_SIZE_ASSERT(MxCompositePresenter, 0x4c);
 
+// OFFSET: LEGO1 0x1000caf0
+MxBool MxCompositePresenter::VTable0x64(undefined4 p_unknown)
+{
+	if (m_compositePresenter)
+		return m_compositePresenter->VTable0x64(p_unknown);
+	return TRUE;
+}
+
 // OFFSET: LEGO1 0x100b60b0
 MxCompositePresenter::MxCompositePresenter()
 {
@@ -33,12 +41,4 @@ void MxCompositePresenter::VTable0x5c()
 void MxCompositePresenter::VTable0x60(undefined4 p_unknown)
 {
 	// TODO
-}
-
-// OFFSET: LEGO1 0x1000caf0
-MxBool MxCompositePresenter::VTable0x64(undefined4 p_unknown)
-{
-	if (m_compositePresenter)
-		return m_compositePresenter->VTable0x64(p_unknown);
-	return TRUE;
 }

--- a/LEGO1/mxcore.cpp
+++ b/LEGO1/mxcore.cpp
@@ -2,6 +2,12 @@
 
 #include "define.h"
 
+// OFFSET: LEGO1 0x10001f70
+MxResult MxCore::Tickle()
+{
+	return SUCCESS;
+}
+
 // OFFSET: LEGO1 0x100ae1a0
 MxCore::MxCore()
 {
@@ -18,10 +24,4 @@ MxCore::~MxCore()
 MxLong MxCore::Notify(MxParam& p)
 {
 	return 0;
-}
-
-// OFFSET: LEGO1 0x10001f70
-MxResult MxCore::Tickle()
-{
-	return SUCCESS;
 }

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -17,17 +17,17 @@ public:
 	__declspec(dllexport) virtual MxLong Notify(MxParam& p); // vtable+04
 	virtual MxResult Tickle();                               // vtable+08
 
+	// OFFSET: LEGO1 0x100140d0
+	inline virtual MxBool IsA(const char* name) const // vtable+10
+	{
+		return !strcmp(name, MxCore::ClassName());
+	}
+
 	// OFFSET: LEGO1 0x100144c0
 	inline virtual const char* ClassName() const // vtable+0c
 	{
 		// 0x100f007c
 		return "MxCore";
-	}
-
-	// OFFSET: LEGO1 0x100140d0
-	inline virtual MxBool IsA(const char* name) const // vtable+10
-	{
-		return !strcmp(name, MxCore::ClassName());
 	}
 
 	inline MxU32 GetId() { return m_id; }

--- a/LEGO1/mxcore.h
+++ b/LEGO1/mxcore.h
@@ -8,6 +8,13 @@
 
 class MxParam;
 
+// TODO: Find proper compilation unit to put these
+// OFFSET: LEGO1 0x100140d0 TEMPLATE
+// MxCore::IsA
+
+// OFFSET: LEGO1 0x100144c0 TEMPLATE
+// MxCore::ClassName
+
 // VTABLE 0x100dc0f8
 // SIZE 0x8
 class MxCore {
@@ -17,17 +24,15 @@ public:
 	__declspec(dllexport) virtual MxLong Notify(MxParam& p); // vtable+04
 	virtual MxResult Tickle();                               // vtable+08
 
-	// OFFSET: LEGO1 0x100140d0
-	inline virtual MxBool IsA(const char* name) const // vtable+10
-	{
-		return !strcmp(name, MxCore::ClassName());
-	}
-
-	// OFFSET: LEGO1 0x100144c0
 	inline virtual const char* ClassName() const // vtable+0c
 	{
 		// 0x100f007c
 		return "MxCore";
+	}
+
+	inline virtual MxBool IsA(const char* name) const // vtable+10
+	{
+		return !strcmp(name, MxCore::ClassName());
 	}
 
 	inline MxU32 GetId() { return m_id; }

--- a/LEGO1/mxcriticalsection.cpp
+++ b/LEGO1/mxcriticalsection.cpp
@@ -31,12 +31,6 @@ MxCriticalSection::~MxCriticalSection()
 	DeleteCriticalSection(&this->m_criticalSection);
 }
 
-// OFFSET: LEGO1 0x100b6e00
-void MxCriticalSection::SetDoMutex()
-{
-	g_useMutex = 1;
-}
-
 // OFFSET: LEGO1 0x100b6d80
 void MxCriticalSection::Enter()
 {
@@ -69,4 +63,10 @@ void MxCriticalSection::Leave()
 	}
 
 	LeaveCriticalSection(&this->m_criticalSection);
+}
+
+// OFFSET: LEGO1 0x100b6e00
+void MxCriticalSection::SetDoMutex()
+{
+	g_useMutex = 1;
 }

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -9,44 +9,10 @@ DECOMP_SIZE_ASSERT(MxDirectDraw::DeviceModesInfo, 0x17c);
 #define DDSCAPS_3DDEVICE 0x00002000l
 #endif
 
-// GLOBAL OFFSET: LEGO1 0x10100C68
+// GLOBAL OFFSET: LEGO1 0x10100c68
 BOOL g_is_PALETTEINDEXED8 = 0;
 
-// OFFSET: LEGO1 0x1009DA20
-void EnableResizing(HWND hwnd, BOOL flag)
-{
-	static DWORD dwStyle;
-
-	if (!flag) {
-		dwStyle = GetWindowLong(hwnd, GWL_STYLE);
-		if (dwStyle & WS_THICKFRAME) {
-			SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) ^ WS_THICKFRAME);
-		}
-	}
-	else {
-		SetWindowLong(hwnd, GWL_STYLE, dwStyle);
-	}
-}
-
-// OFFSET: LEGO1 0x1009efb0
-MxDirectDraw::DeviceModesInfo::DeviceModesInfo()
-{
-	memset(this, 0, sizeof(*this));
-}
-
-// OFFSET: LEGO1 0x1009EFD0
-MxDirectDraw::DeviceModesInfo::~DeviceModesInfo()
-{
-	if (p_guid != NULL) {
-		delete p_guid;
-	}
-
-	if (m_mode_ARRAY != NULL) {
-		delete m_mode_ARRAY;
-	}
-}
-
-// OFFSET: LEGO1 0x1009D490
+// OFFSET: LEGO1 0x1009d490
 MxDirectDraw::MxDirectDraw()
 {
 	m_pFrontBuffer = NULL;
@@ -73,7 +39,7 @@ MxDirectDraw::MxDirectDraw()
 	m_hFont = NULL;
 }
 
-// OFFSET: LEGO1 0x1009D530
+// OFFSET: LEGO1 0x1009d530
 MxDirectDraw::~MxDirectDraw()
 {
 	Destroy();
@@ -106,7 +72,7 @@ int MxDirectDraw::GetPrimaryBitDepth()
 	return dwRGBBitCount;
 }
 
-// OFFSET: LEGO1 0x1009D5E0
+// OFFSET: LEGO1 0x1009d5e0
 BOOL MxDirectDraw::Create(
 	HWND hWnd,
 	BOOL fullscreen_1,
@@ -151,7 +117,82 @@ BOOL MxDirectDraw::Create(
 	return TRUE;
 }
 
-// OFFSET: LEGO1 0x1009D800
+// OFFSET: LEGO1 0x1009d690
+BOOL MxDirectDraw::RecreateDirectDraw(GUID** ppGUID)
+{
+	if (m_pDirectDraw) {
+		m_pDirectDraw->Release();
+		m_pDirectDraw = NULL;
+	}
+
+	return (DirectDrawCreate(*ppGUID, &m_pDirectDraw, 0) == DD_OK);
+}
+
+// OFFSET: LEGO1 0x1009d6c0
+BOOL MxDirectDraw::CacheOriginalPaletteEntries()
+{
+	HDC DC;
+
+	if (g_is_PALETTEINDEXED8) {
+		DC = GetDC(0);
+		GetSystemPaletteEntries(DC, 0, _countof(m_originalPaletteEntries), m_originalPaletteEntries);
+		ReleaseDC(0, DC);
+	}
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009d700
+BOOL MxDirectDraw::SetPaletteEntries(const PALETTEENTRY* pPaletteEntries, int paletteEntryCount, BOOL fullscreen)
+{
+	int reservedLowEntryCount = 10;
+	int reservedHighEntryCount = 10;
+	int arraySize = _countof(m_paletteEntries);
+	HDC hdc;
+	int i;
+
+	if (g_is_PALETTEINDEXED8) {
+		hdc = GetDC(NULL);
+		GetSystemPaletteEntries(hdc, 0, arraySize, m_paletteEntries);
+		ReleaseDC(NULL, hdc);
+	}
+
+	for (i = 0; i < reservedLowEntryCount; i++) {
+		m_paletteEntries[i].peFlags = 0x80;
+	}
+
+	for (i = reservedLowEntryCount; i < 142; i++) {
+		m_paletteEntries[i].peFlags = 0x44;
+	}
+
+	for (i = 142; i < arraySize - reservedHighEntryCount; i++) {
+		m_paletteEntries[i].peFlags = 0x84;
+	}
+
+	for (i = arraySize - reservedHighEntryCount; i < arraySize; i++) {
+		m_paletteEntries[i].peFlags = 0x80;
+	}
+
+	if (paletteEntryCount != 0) {
+		for (i = reservedLowEntryCount; (i < paletteEntryCount) && (i < arraySize - reservedHighEntryCount); i++) {
+			m_paletteEntries[i].peRed = pPaletteEntries[i].peRed;
+			m_paletteEntries[i].peGreen = pPaletteEntries[i].peGreen;
+			m_paletteEntries[i].peBlue = pPaletteEntries[i].peBlue;
+		}
+	}
+
+	if (m_pPalette != NULL) {
+		HRESULT result;
+		result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
+		if (result != DD_OK) {
+			Error("SetEntries failed", result);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009d800
 void MxDirectDraw::Destroy()
 {
 	DestroyButNotDirectDraw();
@@ -171,7 +212,7 @@ void MxDirectDraw::Destroy()
 	}
 }
 
-// OFFSET: LEGO1 0x1009D860
+// OFFSET: LEGO1 0x1009d860
 void MxDirectDraw::DestroyButNotDirectDraw()
 {
 	RestoreOriginalPaletteEntries();
@@ -219,6 +260,542 @@ void MxDirectDraw::DestroyButNotDirectDraw()
 	}
 }
 
+// OFFSET: LEGO1 0x1009d920
+void MxDirectDraw::FUN_1009D920()
+{
+	RestoreOriginalPaletteEntries();
+	if (m_pDirectDraw != NULL) {
+		m_bIgnoreWM_SIZE = TRUE;
+		m_pDirectDraw->RestoreDisplayMode();
+		m_pDirectDraw->SetCooperativeLevel(NULL, DDSCL_NORMAL);
+		m_bIgnoreWM_SIZE = FALSE;
+	}
+}
+
+// OFFSET: LEGO1 0x1009d960
+BOOL MxDirectDraw::DDInit(BOOL fullscreen)
+{
+	HRESULT result;
+
+	if (fullscreen) {
+		m_bIgnoreWM_SIZE = 1;
+		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN);
+		m_bIgnoreWM_SIZE = 0;
+	}
+	else {
+		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_NORMAL);
+	}
+
+	if (result != DD_OK) {
+		Error("SetCooperativeLevel failed", result);
+		return FALSE;
+	}
+
+	m_bFullScreen = fullscreen;
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009d9d0
+BOOL MxDirectDraw::IsSupportedMode(int width, int height, int bpp)
+{
+	Mode mode = {width, height, bpp};
+
+	for (int i = 0; i < m_pCurrentDeviceModesList->count; i++) {
+		if (m_pCurrentDeviceModesList->m_mode_ARRAY[i] == mode) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+// OFFSET: LEGO1 0x1009da20
+void EnableResizing(HWND hwnd, BOOL flag)
+{
+	static DWORD dwStyle;
+
+	if (!flag) {
+		dwStyle = GetWindowLong(hwnd, GWL_STYLE);
+		if (dwStyle & WS_THICKFRAME) {
+			SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) ^ WS_THICKFRAME);
+		}
+	}
+	else {
+		SetWindowLong(hwnd, GWL_STYLE, dwStyle);
+	}
+}
+
+// OFFSET: LEGO1 0x1009da80
+BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
+{
+	HRESULT result;
+
+	if (m_bFullScreen) {
+		LPDIRECTDRAW lpDD;
+
+		EnableResizing(m_hWndMain, FALSE);
+
+		if (!m_bIsOnPrimaryDevice) {
+			lpDD = NULL;
+			result = DirectDrawCreate(0, &lpDD, 0);
+			if (result == DD_OK) {
+				result = lpDD->SetCooperativeLevel(m_hWndMain, DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT);
+				if (result == DD_OK) {
+					lpDD->SetDisplayMode(width, height, 8);
+				}
+			}
+		}
+
+		if (!IsSupportedMode(width, height, bpp)) {
+			width = m_pCurrentDeviceModesList->m_mode_ARRAY[0].width;
+			height = m_pCurrentDeviceModesList->m_mode_ARRAY[0].height;
+			bpp = m_pCurrentDeviceModesList->m_mode_ARRAY[0].bitsPerPixel;
+		}
+
+		m_bIgnoreWM_SIZE = TRUE;
+		result = m_pDirectDraw->SetDisplayMode(width, height, bpp);
+		m_bIgnoreWM_SIZE = FALSE;
+		if (result != DD_OK) {
+			Error("SetDisplayMode failed", result);
+			return FALSE;
+		}
+	}
+	else {
+		RECT rc;
+		DWORD dwStyle;
+
+		if (!m_bIsOnPrimaryDevice) {
+			Error("Attempt made enter a windowed mode on a DirectDraw device that is not the primary display", E_FAIL);
+			return FALSE;
+		}
+
+		m_bIgnoreWM_SIZE = TRUE;
+		dwStyle = GetWindowLong(m_hWndMain, GWL_STYLE);
+		dwStyle &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED);
+		dwStyle |= WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED;
+		SetWindowLong(m_hWndMain, GWL_STYLE, dwStyle);
+
+		SetRect(&rc, 0, 0, width - 1, height - 1);
+		AdjustWindowRectEx(
+			&rc,
+			GetWindowLong(m_hWndMain, GWL_STYLE),
+			GetMenu(m_hWndMain) != NULL,
+			GetWindowLong(m_hWndMain, GWL_EXSTYLE)
+		);
+		SetWindowPos(
+			m_hWndMain,
+			NULL,
+			0,
+			0,
+			rc.right - rc.left + 1,
+			rc.bottom - rc.top + 1,
+			SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE
+		);
+		SetWindowPos(m_hWndMain, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
+		m_bIgnoreWM_SIZE = FALSE;
+	}
+
+	m_currentMode.width = width;
+	m_currentMode.height = height;
+	m_currentMode.bitsPerPixel = bpp;
+
+	if (!DDCreateSurfaces()) {
+		return FALSE;
+	}
+
+	DDSURFACEDESC ddsd;
+
+	FUN_1009E020();
+
+	if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+		return FALSE;
+	}
+
+	if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) {
+		m_bPrimaryPalettized = TRUE;
+	}
+	else {
+		m_bPrimaryPalettized = FALSE;
+	}
+
+	if (m_bPrimaryPalettized) {
+		result = m_pDirectDraw->CreatePalette(
+			DDPCAPS_8BIT | DDPCAPS_ALLOW256 | DDPCAPS_INITIALIZE, // 0x4c
+			m_paletteEntries,
+			&m_pPalette,
+			NULL
+		);
+		if (result != DD_OK) {
+			Error("CreatePalette failed", result);
+			return 0;
+		}
+		result = m_pBackBuffer->SetPalette(m_pPalette); // TODO: add FIX_BUGS define and fix this
+		result = m_pFrontBuffer->SetPalette(m_pPalette);
+		if (result != DD_OK) {
+			Error("SetPalette failed", result);
+			return FALSE;
+		}
+	}
+
+	// create debug text only in windowed mode?
+	return m_bFullScreen || CreateTextSurfaces();
+}
+
+// OFFSET: LEGO1 0x1009dd80
+HRESULT MxDirectDraw::CreateDDSurface(LPDDSURFACEDESC a2, LPDIRECTDRAWSURFACE* a3, IUnknown* a4)
+{
+	return m_pDirectDraw->CreateSurface(a2, a3, a4);
+}
+
+// OFFSET: LEGO1 0x1009dda0
+BOOL MxDirectDraw::GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf)
+{
+	HRESULT result;
+
+	memset(lpDDSurfDesc, 0, sizeof(*lpDDSurfDesc));
+	lpDDSurfDesc->dwSize = sizeof(*lpDDSurfDesc);
+	result = lpDDSurf->GetSurfaceDesc(lpDDSurfDesc);
+	if (result != DD_OK) {
+		Error("Error getting a surface description", result);
+	}
+
+	return (result == DD_OK);
+}
+
+// OFFSET: LEGO1 0x1009ddf0
+BOOL MxDirectDraw::DDCreateSurfaces()
+{
+	HRESULT result;
+	DDSCAPS ddscaps;
+	DDSURFACEDESC ddsd;
+
+	if (m_bFlipSurfaces) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX;
+		if (m_bOnlySystemMemory) {
+			ddsd.ddsCaps.dwCaps =
+				DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX | DDSCAPS_SYSTEMMEMORY;
+		}
+		ddsd.dwBackBufferCount = 1;
+		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, 0);
+		if (result != DD_OK) {
+			Error("CreateSurface for front/back fullScreen buffer failed", result);
+			return FALSE;
+		}
+
+		ddscaps.dwCaps = DDSCAPS_BACKBUFFER;
+		result = m_pFrontBuffer->GetAttachedSurface(&ddscaps, &m_pBackBuffer);
+		if (result != DD_OK) {
+			Error("GetAttachedSurface failed to get back buffer", result);
+			return FALSE;
+		}
+		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+			return FALSE;
+		}
+	}
+	else {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+		ddsd.dwFlags = DDSD_CAPS;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
+		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, NULL);
+		if (result != DD_OK) {
+			Error("CreateSurface for window front buffer failed", result);
+			return FALSE;
+		}
+		ddsd.dwHeight = m_currentMode.height;
+		ddsd.dwWidth = m_currentMode.width;
+		ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
+		ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE;
+		if (m_bOnlySystemMemory)
+			ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY;
+		result = CreateDDSurface(&ddsd, &m_pBackBuffer, NULL);
+		if (result != DD_OK) {
+			Error("CreateSurface for window back buffer failed", result);
+			return FALSE;
+		}
+
+		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
+			return FALSE;
+		}
+
+		result = m_pDirectDraw->CreateClipper(0, &m_pClipper, NULL);
+		if (result != DD_OK) {
+			Error("CreateClipper failed", result);
+			return FALSE;
+		}
+		result = m_pClipper->SetHWnd(0, m_hWndMain);
+		if (result != DD_OK) {
+			Error("Clipper SetHWnd failed", result);
+			return FALSE;
+		}
+		result = m_pFrontBuffer->SetClipper(m_pClipper);
+		if (result != DD_OK) {
+			Error("SetClipper failed", result);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e020
+void MxDirectDraw::FUN_1009E020()
+{
+	HRESULT result;
+	byte* line;
+	DDSURFACEDESC ddsd;
+	int j;
+	int count = m_bFlipSurfaces ? 2 : 1;
+
+	for (int i = 0; i < count; i++) {
+		memset(&ddsd, 0, sizeof(ddsd));
+		ddsd.dwSize = sizeof(ddsd);
+
+		result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
+		if (result == DDERR_SURFACELOST) {
+			m_pBackBuffer->Restore();
+			result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
+		}
+
+		if (result != DD_OK) {
+			// lock failed
+			return;
+		}
+
+		// clear backBuffer
+		line = (byte*) ddsd.lpSurface;
+		for (j = ddsd.dwHeight; j--;) {
+			memset(line, 0, ddsd.dwWidth);
+			line += ddsd.lPitch;
+		}
+
+		m_pBackBuffer->Unlock(ddsd.lpSurface);
+
+		if (m_bFlipSurfaces) {
+			m_pFrontBuffer->Flip(NULL, DDFLIP_WAIT);
+		}
+	}
+}
+
+// OFFSET: LEGO1 0x1009e110
+BOOL MxDirectDraw::TextToTextSurface(const char* text, IDirectDrawSurface* pSurface, SIZE& textSizeOnSurface)
+{
+	HRESULT result;
+	HDC hdc;
+	RECT rc;
+	size_t textLength;
+
+	if (pSurface == NULL) {
+		return FALSE;
+	}
+
+	result = pSurface->GetDC(&hdc);
+	if (result != DD_OK) {
+		Error("GetDC for text surface failed", result);
+		return FALSE;
+	}
+
+	textLength = strlen(text);
+
+	SelectObject(hdc, m_hFont);
+	SetTextColor(hdc, RGB(255, 255, 0));
+	SetBkColor(hdc, RGB(0, 0, 0));
+	SetBkMode(hdc, OPAQUE);
+	GetTextExtentPoint32(hdc, text, textLength, &textSizeOnSurface);
+	SetRect(&rc, 0, 0, textSizeOnSurface.cx, textSizeOnSurface.cy);
+	ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, text, textLength, NULL);
+	pSurface->ReleaseDC(hdc);
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e210
+BOOL MxDirectDraw::TextToTextSurface1(const char* text)
+{
+	return TextToTextSurface(text, m_pText1Surface, m_text1SizeOnSurface);
+}
+
+// OFFSET: LEGO1 0x1009e230
+BOOL MxDirectDraw::TextToTextSurface2(const char* text)
+{
+	return TextToTextSurface(text, m_pText2Surface, m_text2SizeOnSurface);
+}
+
+// OFFSET: LEGO1 0x1009e250
+BOOL MxDirectDraw::CreateTextSurfaces()
+{
+	HRESULT result;
+	DDCOLORKEY ddck;
+	DDSURFACEDESC ddsd;
+	HDC DC;
+	char dummyinfo[] = "000x000x00 (RAMP) 0000";
+	char dummyfps[] = "000.00 fps (000.00 fps (000.00 fps) 00000 tps)";
+
+	if (m_hFont != NULL) {
+		DeleteObject(m_hFont);
+	}
+
+	m_hFont = CreateFontA(
+		m_currentMode.width <= 600 ? 12 : 24,
+		0,
+		0,
+		0,
+		FW_NORMAL,
+		FALSE,
+		FALSE,
+		FALSE,
+		ANSI_CHARSET,
+		OUT_DEFAULT_PRECIS,
+		CLIP_DEFAULT_PRECIS,
+		DEFAULT_QUALITY,
+		VARIABLE_PITCH,
+		"Arial"
+	);
+
+	DC = GetDC(NULL);
+	SelectObject(DC, m_hFont);
+	GetTextExtentPointA(DC, dummyfps, strlen(dummyfps), &m_text1SizeOnSurface);
+	GetTextExtentPointA(DC, dummyinfo, strlen(dummyinfo), &m_text2SizeOnSurface);
+	ReleaseDC(NULL, DC);
+
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
+	if (m_bOnlySystemMemory)
+		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
+	ddsd.dwHeight = m_text1SizeOnSurface.cy;
+	ddsd.dwWidth = m_text1SizeOnSurface.cx;
+
+	result = CreateDDSurface(&ddsd, &m_pText1Surface, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for text surface 1 failed", result);
+		return FALSE;
+	}
+
+	memset(&ddck, 0, sizeof(ddck));
+	m_pText1Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
+	if (!TextToTextSurface1(dummyfps)) {
+		return FALSE;
+	}
+
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
+	if (m_bOnlySystemMemory)
+		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
+	ddsd.dwHeight = m_text2SizeOnSurface.cy;
+	ddsd.dwWidth = m_text2SizeOnSurface.cx;
+
+	result = CreateDDSurface(&ddsd, &m_pText2Surface, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for text surface 2 failed", result);
+		return FALSE;
+	}
+
+	memset(&ddck, 0, sizeof(ddck));
+	m_pText2Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
+	if (!TextToTextSurface2(dummyinfo)) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e4d0
+BOOL MxDirectDraw::RestoreSurfaces()
+{
+	HRESULT result;
+
+	if (m_pFrontBuffer != NULL) {
+		if (m_pFrontBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pFrontBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of front buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	if (m_pBackBuffer != NULL) {
+		if (m_pBackBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pBackBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of back buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	if (m_pZBuffer != NULL) {
+		if (m_pZBuffer->IsLost() == DDERR_SURFACELOST) {
+			result = m_pZBuffer->Restore();
+			if (result != DD_OK) {
+				Error("Restore of Z-buffer failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	if (m_pText1Surface != NULL) {
+		if (m_pText1Surface->IsLost() == DDERR_SURFACELOST) {
+			result = m_pText1Surface->Restore();
+			if (result != DD_OK) {
+				Error("Restore of text surface 1 failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	if (m_pText2Surface != NULL) {
+		if (m_pText2Surface->IsLost() == DDERR_SURFACELOST) {
+			result = m_pText2Surface->Restore();
+			if (result != DD_OK) {
+				Error("Restore of text surface 2 failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e5e0
+BOOL MxDirectDraw::CreateZBuffer(DWORD memorytype, DWORD depth)
+{
+	HRESULT result;                // eax
+	LPDIRECTDRAWSURFACE lpZBuffer; // [esp+8h] [ebp-70h] BYREF
+	DDSURFACEDESC ddsd;
+
+	memset(&ddsd, 0, sizeof(ddsd));
+	ddsd.dwSize = sizeof(ddsd);
+	ddsd.dwHeight = m_currentMode.height;
+	ddsd.dwWidth = m_currentMode.width;
+	ddsd.dwZBufferBitDepth = depth;
+	ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS | DDSD_ZBUFFERBITDEPTH;
+	ddsd.ddsCaps.dwCaps = DDSCAPS_ZBUFFER | memorytype;
+
+	result = CreateDDSurface(&ddsd, &lpZBuffer, 0);
+	if (result != DD_OK) {
+		Error("CreateSurface for fullScreen Z-buffer failed", result);
+		return FALSE;
+	}
+
+	result = m_pBackBuffer->AddAttachedSurface(lpZBuffer);
+	if (result != DD_OK) {
+		Error("AddAttachedBuffer failed for Z-Buffer", result);
+		return FALSE;
+	}
+
+	m_pZBuffer = lpZBuffer;
+	return TRUE;
+}
+
 // OFFSET: LEGO1 0x1009e6a0
 int MxDirectDraw::Pause(int p_increment)
 {
@@ -259,7 +836,74 @@ int MxDirectDraw::Pause(int p_increment)
 	return TRUE;
 }
 
-// OFFSET: LEGO1 0x1009E880
+// OFFSET: LEGO1 0x1009e750
+BOOL MxDirectDraw::RestorePaletteEntries()
+{
+	HRESULT result;
+
+	if (m_bFullScreen && m_bPrimaryPalettized) {
+		if (m_pPalette) {
+			result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
+			if (result != DD_OK) {
+				Error("SetEntries failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e7a0
+BOOL MxDirectDraw::RestoreOriginalPaletteEntries()
+{
+	HRESULT result;
+
+	if (m_bPrimaryPalettized) {
+		if (m_pPalette) {
+			result = m_pPalette->SetEntries(0, 0, 256, m_originalPaletteEntries);
+			if (result != DD_OK) {
+				Error("SetEntries failed", result);
+				return FALSE;
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009e7f0
+int MxDirectDraw::FlipToGDISurface()
+{
+	HRESULT ret;
+
+	if (m_pDirectDraw) {
+		ret = m_pDirectDraw->FlipToGDISurface();
+		if (ret != DD_OK) {
+			Error("FlipToGDISurface failed", ret);
+		}
+		return !ret;
+	}
+
+	return 1;
+}
+
+// OFFSET: LEGO1 0x1009e830
+void MxDirectDraw::Error(const char* message, int error)
+{
+	// 0x10100c70
+	static BOOL isInsideError = FALSE;
+	if (!isInsideError) {
+		isInsideError = TRUE;
+		Destroy();
+		if (m_pErrorHandler) {
+			m_pErrorHandler(message, error, m_pErrorHandlerArg);
+		}
+		isInsideError = FALSE;
+	}
+}
+
+// OFFSET: LEGO1 0x1009e880
 const char* MxDirectDraw::ErrorToString(HRESULT error)
 {
 	switch (error) {
@@ -469,664 +1113,20 @@ const char* MxDirectDraw::ErrorToString(HRESULT error)
 	}
 }
 
-// OFFSET: LEGO1 0x1009D6C0
-BOOL MxDirectDraw::CacheOriginalPaletteEntries()
+// OFFSET: LEGO1 0x1009efb0
+MxDirectDraw::DeviceModesInfo::DeviceModesInfo()
 {
-	HDC DC;
-
-	if (g_is_PALETTEINDEXED8) {
-		DC = GetDC(0);
-		GetSystemPaletteEntries(DC, 0, _countof(m_originalPaletteEntries), m_originalPaletteEntries);
-		ReleaseDC(0, DC);
-	}
-	return TRUE;
+	memset(this, 0, sizeof(*this));
 }
 
-// OFFSET: LEGO1 0x1009DD80
-HRESULT MxDirectDraw::CreateDDSurface(LPDDSURFACEDESC a2, LPDIRECTDRAWSURFACE* a3, IUnknown* a4)
+// OFFSET: LEGO1 0x1009efd0
+MxDirectDraw::DeviceModesInfo::~DeviceModesInfo()
 {
-	return m_pDirectDraw->CreateSurface(a2, a3, a4);
-}
-
-// OFFSET: LEGO1 0x1009E250
-BOOL MxDirectDraw::CreateTextSurfaces()
-{
-	HRESULT result;
-	DDCOLORKEY ddck;
-	DDSURFACEDESC ddsd;
-	HDC DC;
-	char dummyinfo[] = "000x000x00 (RAMP) 0000";
-	char dummyfps[] = "000.00 fps (000.00 fps (000.00 fps) 00000 tps)";
-
-	if (m_hFont != NULL) {
-		DeleteObject(m_hFont);
+	if (p_guid != NULL) {
+		delete p_guid;
 	}
 
-	m_hFont = CreateFontA(
-		m_currentMode.width <= 600 ? 12 : 24,
-		0,
-		0,
-		0,
-		FW_NORMAL,
-		FALSE,
-		FALSE,
-		FALSE,
-		ANSI_CHARSET,
-		OUT_DEFAULT_PRECIS,
-		CLIP_DEFAULT_PRECIS,
-		DEFAULT_QUALITY,
-		VARIABLE_PITCH,
-		"Arial"
-	);
-
-	DC = GetDC(NULL);
-	SelectObject(DC, m_hFont);
-	GetTextExtentPointA(DC, dummyfps, strlen(dummyfps), &m_text1SizeOnSurface);
-	GetTextExtentPointA(DC, dummyinfo, strlen(dummyinfo), &m_text2SizeOnSurface);
-	ReleaseDC(NULL, DC);
-
-	memset(&ddsd, 0, sizeof(ddsd));
-	ddsd.dwSize = sizeof(ddsd);
-	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
-	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
-	if (m_bOnlySystemMemory)
-		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
-	ddsd.dwHeight = m_text1SizeOnSurface.cy;
-	ddsd.dwWidth = m_text1SizeOnSurface.cx;
-
-	result = CreateDDSurface(&ddsd, &m_pText1Surface, 0);
-	if (result != DD_OK) {
-		Error("CreateSurface for text surface 1 failed", result);
-		return FALSE;
-	}
-
-	memset(&ddck, 0, sizeof(ddck));
-	m_pText1Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
-	if (!TextToTextSurface1(dummyfps)) {
-		return FALSE;
-	}
-
-	memset(&ddsd, 0, sizeof(ddsd));
-	ddsd.dwSize = sizeof(ddsd);
-	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
-	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
-	if (m_bOnlySystemMemory)
-		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_OFFSCREENPLAIN;
-	ddsd.dwHeight = m_text2SizeOnSurface.cy;
-	ddsd.dwWidth = m_text2SizeOnSurface.cx;
-
-	result = CreateDDSurface(&ddsd, &m_pText2Surface, 0);
-	if (result != DD_OK) {
-		Error("CreateSurface for text surface 2 failed", result);
-		return FALSE;
-	}
-
-	memset(&ddck, 0, sizeof(ddck));
-	m_pText2Surface->SetColorKey(DDCKEY_SRCBLT, &ddck);
-	if (!TextToTextSurface2(dummyinfo)) {
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009E5E0
-BOOL MxDirectDraw::CreateZBuffer(DWORD memorytype, DWORD depth)
-{
-	HRESULT result;                // eax
-	LPDIRECTDRAWSURFACE lpZBuffer; // [esp+8h] [ebp-70h] BYREF
-	DDSURFACEDESC ddsd;
-
-	memset(&ddsd, 0, sizeof(ddsd));
-	ddsd.dwSize = sizeof(ddsd);
-	ddsd.dwHeight = m_currentMode.height;
-	ddsd.dwWidth = m_currentMode.width;
-	ddsd.dwZBufferBitDepth = depth;
-	ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS | DDSD_ZBUFFERBITDEPTH;
-	ddsd.ddsCaps.dwCaps = DDSCAPS_ZBUFFER | memorytype;
-
-	result = CreateDDSurface(&ddsd, &lpZBuffer, 0);
-	if (result != DD_OK) {
-		Error("CreateSurface for fullScreen Z-buffer failed", result);
-		return FALSE;
-	}
-
-	result = m_pBackBuffer->AddAttachedSurface(lpZBuffer);
-	if (result != DD_OK) {
-		Error("AddAttachedBuffer failed for Z-Buffer", result);
-		return FALSE;
-	}
-
-	m_pZBuffer = lpZBuffer;
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009DDF0
-BOOL MxDirectDraw::DDCreateSurfaces()
-{
-	HRESULT result;
-	DDSCAPS ddscaps;
-	DDSURFACEDESC ddsd;
-
-	if (m_bFlipSurfaces) {
-		memset(&ddsd, 0, sizeof(ddsd));
-		ddsd.dwSize = sizeof(ddsd);
-		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX;
-		if (m_bOnlySystemMemory) {
-			ddsd.ddsCaps.dwCaps =
-				DDSCAPS_PRIMARYSURFACE | DDSCAPS_FLIP | DDSCAPS_3DDEVICE | DDSCAPS_COMPLEX | DDSCAPS_SYSTEMMEMORY;
-		}
-		ddsd.dwBackBufferCount = 1;
-		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, 0);
-		if (result != DD_OK) {
-			Error("CreateSurface for front/back fullScreen buffer failed", result);
-			return FALSE;
-		}
-
-		ddscaps.dwCaps = DDSCAPS_BACKBUFFER;
-		result = m_pFrontBuffer->GetAttachedSurface(&ddscaps, &m_pBackBuffer);
-		if (result != DD_OK) {
-			Error("GetAttachedSurface failed to get back buffer", result);
-			return FALSE;
-		}
-		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
-			return FALSE;
-		}
-	}
-	else {
-		memset(&ddsd, 0, sizeof(ddsd));
-		ddsd.dwSize = sizeof(ddsd);
-		ddsd.dwFlags = DDSD_CAPS;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
-		result = CreateDDSurface(&ddsd, &m_pFrontBuffer, NULL);
-		if (result != DD_OK) {
-			Error("CreateSurface for window front buffer failed", result);
-			return FALSE;
-		}
-		ddsd.dwHeight = m_currentMode.height;
-		ddsd.dwWidth = m_currentMode.width;
-		ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE;
-		if (m_bOnlySystemMemory)
-			ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_3DDEVICE | DDSCAPS_SYSTEMMEMORY;
-		result = CreateDDSurface(&ddsd, &m_pBackBuffer, NULL);
-		if (result != DD_OK) {
-			Error("CreateSurface for window back buffer failed", result);
-			return FALSE;
-		}
-
-		if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
-			return FALSE;
-		}
-
-		result = m_pDirectDraw->CreateClipper(0, &m_pClipper, NULL);
-		if (result != DD_OK) {
-			Error("CreateClipper failed", result);
-			return FALSE;
-		}
-		result = m_pClipper->SetHWnd(0, m_hWndMain);
-		if (result != DD_OK) {
-			Error("Clipper SetHWnd failed", result);
-			return FALSE;
-		}
-		result = m_pFrontBuffer->SetClipper(m_pClipper);
-		if (result != DD_OK) {
-			Error("SetClipper failed", result);
-			return FALSE;
-		}
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009D960
-BOOL MxDirectDraw::DDInit(BOOL fullscreen)
-{
-	HRESULT result;
-
-	if (fullscreen) {
-		m_bIgnoreWM_SIZE = 1;
-		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN);
-		m_bIgnoreWM_SIZE = 0;
-	}
-	else {
-		result = m_pDirectDraw->SetCooperativeLevel(m_hWndMain, DDSCL_NORMAL);
-	}
-
-	if (result != DD_OK) {
-		Error("SetCooperativeLevel failed", result);
-		return FALSE;
-	}
-
-	m_bFullScreen = fullscreen;
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009DA80
-BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
-{
-	HRESULT result;
-
-	if (m_bFullScreen) {
-		LPDIRECTDRAW lpDD;
-
-		EnableResizing(m_hWndMain, FALSE);
-
-		if (!m_bIsOnPrimaryDevice) {
-			lpDD = NULL;
-			result = DirectDrawCreate(0, &lpDD, 0);
-			if (result == DD_OK) {
-				result = lpDD->SetCooperativeLevel(m_hWndMain, DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT);
-				if (result == DD_OK) {
-					lpDD->SetDisplayMode(width, height, 8);
-				}
-			}
-		}
-
-		if (!IsSupportedMode(width, height, bpp)) {
-			width = m_pCurrentDeviceModesList->m_mode_ARRAY[0].width;
-			height = m_pCurrentDeviceModesList->m_mode_ARRAY[0].height;
-			bpp = m_pCurrentDeviceModesList->m_mode_ARRAY[0].bitsPerPixel;
-		}
-
-		m_bIgnoreWM_SIZE = TRUE;
-		result = m_pDirectDraw->SetDisplayMode(width, height, bpp);
-		m_bIgnoreWM_SIZE = FALSE;
-		if (result != DD_OK) {
-			Error("SetDisplayMode failed", result);
-			return FALSE;
-		}
-	}
-	else {
-		RECT rc;
-		DWORD dwStyle;
-
-		if (!m_bIsOnPrimaryDevice) {
-			Error("Attempt made enter a windowed mode on a DirectDraw device that is not the primary display", E_FAIL);
-			return FALSE;
-		}
-
-		m_bIgnoreWM_SIZE = TRUE;
-		dwStyle = GetWindowLong(m_hWndMain, GWL_STYLE);
-		dwStyle &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED);
-		dwStyle |= WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPED;
-		SetWindowLong(m_hWndMain, GWL_STYLE, dwStyle);
-
-		SetRect(&rc, 0, 0, width - 1, height - 1);
-		AdjustWindowRectEx(
-			&rc,
-			GetWindowLong(m_hWndMain, GWL_STYLE),
-			GetMenu(m_hWndMain) != NULL,
-			GetWindowLong(m_hWndMain, GWL_EXSTYLE)
-		);
-		SetWindowPos(
-			m_hWndMain,
-			NULL,
-			0,
-			0,
-			rc.right - rc.left + 1,
-			rc.bottom - rc.top + 1,
-			SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE
-		);
-		SetWindowPos(m_hWndMain, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
-		m_bIgnoreWM_SIZE = FALSE;
-	}
-
-	m_currentMode.width = width;
-	m_currentMode.height = height;
-	m_currentMode.bitsPerPixel = bpp;
-
-	if (!DDCreateSurfaces()) {
-		return FALSE;
-	}
-
-	DDSURFACEDESC ddsd;
-
-	FUN_1009E020();
-
-	if (!GetDDSurfaceDesc(&ddsd, m_pBackBuffer)) {
-		return FALSE;
-	}
-
-	if (ddsd.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8) {
-		m_bPrimaryPalettized = TRUE;
-	}
-	else {
-		m_bPrimaryPalettized = FALSE;
-	}
-
-	if (m_bPrimaryPalettized) {
-		result = m_pDirectDraw->CreatePalette(
-			DDPCAPS_8BIT | DDPCAPS_ALLOW256 | DDPCAPS_INITIALIZE, // 0x4c
-			m_paletteEntries,
-			&m_pPalette,
-			NULL
-		);
-		if (result != DD_OK) {
-			Error("CreatePalette failed", result);
-			return 0;
-		}
-		result = m_pBackBuffer->SetPalette(m_pPalette); // TODO: add FIX_BUGS define and fix this
-		result = m_pFrontBuffer->SetPalette(m_pPalette);
-		if (result != DD_OK) {
-			Error("SetPalette failed", result);
-			return FALSE;
-		}
-	}
-
-	// create debug text only in windowed mode?
-	return m_bFullScreen || CreateTextSurfaces();
-}
-
-// OFFSET: LEGO1 0x1009E830
-void MxDirectDraw::Error(const char* message, int error)
-{
-	// OFFSET: LEGO1 0x10100C70
-	static BOOL isInsideError = FALSE;
-	if (!isInsideError) {
-		isInsideError = TRUE;
-		Destroy();
-		if (m_pErrorHandler) {
-			m_pErrorHandler(message, error, m_pErrorHandlerArg);
-		}
-		isInsideError = FALSE;
-	}
-}
-
-// OFFSET: LEGO1 0x1009DDA0
-BOOL MxDirectDraw::GetDDSurfaceDesc(LPDDSURFACEDESC lpDDSurfDesc, LPDIRECTDRAWSURFACE lpDDSurf)
-{
-	HRESULT result;
-
-	memset(lpDDSurfDesc, 0, sizeof(*lpDDSurfDesc));
-	lpDDSurfDesc->dwSize = sizeof(*lpDDSurfDesc);
-	result = lpDDSurf->GetSurfaceDesc(lpDDSurfDesc);
-	if (result != DD_OK) {
-		Error("Error getting a surface description", result);
-	}
-
-	return (result == DD_OK);
-}
-
-// OFFSET: LEGO1 0x1009D9D0
-BOOL MxDirectDraw::IsSupportedMode(int width, int height, int bpp)
-{
-	Mode mode = {width, height, bpp};
-
-	for (int i = 0; i < m_pCurrentDeviceModesList->count; i++) {
-		if (m_pCurrentDeviceModesList->m_mode_ARRAY[i] == mode) {
-			return TRUE;
-		}
-	}
-
-	return FALSE;
-}
-
-// OFFSET: LEGO1 0x1009D690
-BOOL MxDirectDraw::RecreateDirectDraw(GUID** ppGUID)
-{
-	if (m_pDirectDraw) {
-		m_pDirectDraw->Release();
-		m_pDirectDraw = NULL;
-	}
-
-	return (DirectDrawCreate(*ppGUID, &m_pDirectDraw, 0) == DD_OK);
-}
-
-// OFFSET: LEGO1 0x1009E7A0
-BOOL MxDirectDraw::RestoreOriginalPaletteEntries()
-{
-	HRESULT result;
-
-	if (m_bPrimaryPalettized) {
-		if (m_pPalette) {
-			result = m_pPalette->SetEntries(0, 0, 256, m_originalPaletteEntries);
-			if (result != DD_OK) {
-				Error("SetEntries failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009E750
-BOOL MxDirectDraw::RestorePaletteEntries()
-{
-	HRESULT result;
-
-	if (m_bFullScreen && m_bPrimaryPalettized) {
-		if (m_pPalette) {
-			result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
-			if (result != DD_OK) {
-				Error("SetEntries failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009e7f0
-int MxDirectDraw::FlipToGDISurface()
-{
-	HRESULT ret;
-
-	if (m_pDirectDraw) {
-		ret = m_pDirectDraw->FlipToGDISurface();
-		if (ret != DD_OK) {
-			Error("FlipToGDISurface failed", ret);
-		}
-		return !ret;
-	}
-
-	return 1;
-}
-
-// OFFSET: LEGO1 0x1009E4D0
-BOOL MxDirectDraw::RestoreSurfaces()
-{
-	HRESULT result;
-
-	if (m_pFrontBuffer != NULL) {
-		if (m_pFrontBuffer->IsLost() == DDERR_SURFACELOST) {
-			result = m_pFrontBuffer->Restore();
-			if (result != DD_OK) {
-				Error("Restore of front buffer failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	if (m_pBackBuffer != NULL) {
-		if (m_pBackBuffer->IsLost() == DDERR_SURFACELOST) {
-			result = m_pBackBuffer->Restore();
-			if (result != DD_OK) {
-				Error("Restore of back buffer failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	if (m_pZBuffer != NULL) {
-		if (m_pZBuffer->IsLost() == DDERR_SURFACELOST) {
-			result = m_pZBuffer->Restore();
-			if (result != DD_OK) {
-				Error("Restore of Z-buffer failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	if (m_pText1Surface != NULL) {
-		if (m_pText1Surface->IsLost() == DDERR_SURFACELOST) {
-			result = m_pText1Surface->Restore();
-			if (result != DD_OK) {
-				Error("Restore of text surface 1 failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	if (m_pText2Surface != NULL) {
-		if (m_pText2Surface->IsLost() == DDERR_SURFACELOST) {
-			result = m_pText2Surface->Restore();
-			if (result != DD_OK) {
-				Error("Restore of text surface 2 failed", result);
-				return FALSE;
-			}
-		}
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009D700
-BOOL MxDirectDraw::SetPaletteEntries(const PALETTEENTRY* pPaletteEntries, int paletteEntryCount, BOOL fullscreen)
-{
-	int reservedLowEntryCount = 10;
-	int reservedHighEntryCount = 10;
-	int arraySize = _countof(m_paletteEntries);
-	HDC hdc;
-	int i;
-
-	if (g_is_PALETTEINDEXED8) {
-		hdc = GetDC(NULL);
-		GetSystemPaletteEntries(hdc, 0, arraySize, m_paletteEntries);
-		ReleaseDC(NULL, hdc);
-	}
-
-	for (i = 0; i < reservedLowEntryCount; i++) {
-		m_paletteEntries[i].peFlags = 0x80;
-	}
-
-	for (i = reservedLowEntryCount; i < 142; i++) {
-		m_paletteEntries[i].peFlags = 0x44;
-	}
-
-	for (i = 142; i < arraySize - reservedHighEntryCount; i++) {
-		m_paletteEntries[i].peFlags = 0x84;
-	}
-
-	for (i = arraySize - reservedHighEntryCount; i < arraySize; i++) {
-		m_paletteEntries[i].peFlags = 0x80;
-	}
-
-	if (paletteEntryCount != 0) {
-		for (i = reservedLowEntryCount; (i < paletteEntryCount) && (i < arraySize - reservedHighEntryCount); i++) {
-			m_paletteEntries[i].peRed = pPaletteEntries[i].peRed;
-			m_paletteEntries[i].peGreen = pPaletteEntries[i].peGreen;
-			m_paletteEntries[i].peBlue = pPaletteEntries[i].peBlue;
-		}
-	}
-
-	if (m_pPalette != NULL) {
-		HRESULT result;
-		result = m_pPalette->SetEntries(0, 0, _countof(m_paletteEntries), m_paletteEntries);
-		if (result != DD_OK) {
-			Error("SetEntries failed", result);
-			return FALSE;
-		}
-	}
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009E110
-BOOL MxDirectDraw::TextToTextSurface(const char* text, IDirectDrawSurface* pSurface, SIZE& textSizeOnSurface)
-{
-	HRESULT result;
-	HDC hdc;
-	RECT rc;
-	size_t textLength;
-
-	if (pSurface == NULL) {
-		return FALSE;
-	}
-
-	result = pSurface->GetDC(&hdc);
-	if (result != DD_OK) {
-		Error("GetDC for text surface failed", result);
-		return FALSE;
-	}
-
-	textLength = strlen(text);
-
-	SelectObject(hdc, m_hFont);
-	SetTextColor(hdc, RGB(255, 255, 0));
-	SetBkColor(hdc, RGB(0, 0, 0));
-	SetBkMode(hdc, OPAQUE);
-	GetTextExtentPoint32(hdc, text, textLength, &textSizeOnSurface);
-	SetRect(&rc, 0, 0, textSizeOnSurface.cx, textSizeOnSurface.cy);
-	ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, text, textLength, NULL);
-	pSurface->ReleaseDC(hdc);
-
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x1009E210
-BOOL MxDirectDraw::TextToTextSurface1(const char* text)
-{
-	return TextToTextSurface(text, m_pText1Surface, m_text1SizeOnSurface);
-}
-
-// OFFSET: LEGO1 0x1009E230
-BOOL MxDirectDraw::TextToTextSurface2(const char* text)
-{
-	return TextToTextSurface(text, m_pText2Surface, m_text2SizeOnSurface);
-}
-
-// OFFSET: LEGO1 0x1009E020
-void MxDirectDraw::FUN_1009E020()
-{
-	HRESULT result;
-	byte* line;
-	DDSURFACEDESC ddsd;
-	int j;
-	int count = m_bFlipSurfaces ? 2 : 1;
-
-	for (int i = 0; i < count; i++) {
-		memset(&ddsd, 0, sizeof(ddsd));
-		ddsd.dwSize = sizeof(ddsd);
-
-		result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
-		if (result == DDERR_SURFACELOST) {
-			m_pBackBuffer->Restore();
-			result = m_pBackBuffer->Lock(NULL, &ddsd, 1, NULL);
-		}
-
-		if (result != DD_OK) {
-			// lock failed
-			return;
-		}
-
-		// clear backBuffer
-		line = (byte*) ddsd.lpSurface;
-		for (j = ddsd.dwHeight; j--;) {
-			memset(line, 0, ddsd.dwWidth);
-			line += ddsd.lPitch;
-		}
-
-		m_pBackBuffer->Unlock(ddsd.lpSurface);
-
-		if (m_bFlipSurfaces) {
-			m_pFrontBuffer->Flip(NULL, DDFLIP_WAIT);
-		}
-	}
-}
-
-// OFFSET: LEGO1 0x1009D920
-void MxDirectDraw::FUN_1009D920()
-{
-	RestoreOriginalPaletteEntries();
-	if (m_pDirectDraw != NULL) {
-		m_bIgnoreWM_SIZE = TRUE;
-		m_pDirectDraw->RestoreDisplayMode();
-		m_pDirectDraw->SetCooperativeLevel(NULL, DDSCL_NORMAL);
-		m_bIgnoreWM_SIZE = FALSE;
+	if (m_mode_ARRAY != NULL) {
+		delete m_mode_ARRAY;
 	}
 }

--- a/LEGO1/mxdiskstreamcontroller.cpp
+++ b/LEGO1/mxdiskstreamcontroller.cpp
@@ -17,13 +17,6 @@ MxDiskStreamController::~MxDiskStreamController()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x100c8640 STUB
-MxResult MxDiskStreamController::Tickle()
-{
-	// TODO
-	return SUCCESS;
-}
-
 // OFFSET: LEGO1 0x100c7790
 MxResult MxDiskStreamController::Open(const char* p_filename)
 {
@@ -56,17 +49,9 @@ MxResult MxDiskStreamController::vtable0x18(undefined4 p_unknown, undefined4 p_u
 	return SUCCESS;
 }
 
-// OFFSET: LEGO1 0x100c7ff0 STUB
-MxResult MxDiskStreamController::vtable0x20(MxDSAction* p_action)
+// OFFSET: LEGO1 0x100c7960
+MxResult MxDiskStreamController::vtable0x34(undefined4 p_unknown)
 {
-	// TODO
-	return FAILURE;
-}
-
-// OFFSET: LEGO1 0x100c8160 STUB
-MxResult MxDiskStreamController::vtable0x24(undefined4 p_unknown)
-{
-	// TODO
 	return FAILURE;
 }
 
@@ -84,8 +69,23 @@ MxResult MxDiskStreamController::vtable0x30(undefined4 p_unknown)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100c7960
-MxResult MxDiskStreamController::vtable0x34(undefined4 p_unknown)
+// OFFSET: LEGO1 0x100c7ff0 STUB
+MxResult MxDiskStreamController::vtable0x20(MxDSAction* p_action)
 {
+	// TODO
 	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100c8160 STUB
+MxResult MxDiskStreamController::vtable0x24(undefined4 p_unknown)
+{
+	// TODO
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100c8640 STUB
+MxResult MxDiskStreamController::Tickle()
+{
+	// TODO
+	return SUCCESS;
 }

--- a/LEGO1/mxdiskstreamprovider.cpp
+++ b/LEGO1/mxdiskstreamprovider.cpp
@@ -70,6 +70,12 @@ done:
 	return result;
 }
 
+// OFFSET: LEGO1 0x100d15e0 STUB
+void MxDiskStreamProvider::vtable0x20(undefined4 p_unknown1)
+{
+	// TODO
+}
+
 // OFFSET: LEGO1 0x100d1750
 MxResult MxDiskStreamProvider::WaitForWorkToComplete()
 {
@@ -97,12 +103,6 @@ MxU32 MxDiskStreamProvider::GetFileSize()
 MxU32 MxDiskStreamProvider::GetStreamBuffersNum()
 {
 	return m_pFile->GetStreamBuffersNum();
-}
-
-// OFFSET: LEGO1 0x100d15e0 STUB
-void MxDiskStreamProvider::vtable0x20(undefined4 p_unknown1)
-{
-	// TODO
 }
 
 // OFFSET: LEGO1 0x100d1eb0

--- a/LEGO1/mxdisplaysurface.cpp
+++ b/LEGO1/mxdisplaysurface.cpp
@@ -28,6 +28,12 @@ void MxDisplaySurface::Reset()
 	memset(&this->m_surfaceDesc, 0, sizeof(this->m_surfaceDesc));
 }
 
+// OFFSET: LEGO1 0x100ba640 STUB
+void MxDisplaySurface::FUN_100ba640()
+{
+	// TODO
+}
+
 // OFFSET: LEGO1 0x100ba790
 MxResult MxDisplaySurface::Init(
 	MxVideoParam& p_videoParam,
@@ -178,29 +184,8 @@ void MxDisplaySurface::SetPalette(MxPalette* p_palette)
 {
 }
 
-// OFFSET: LEGO1 0x100bc200 STUB
-void MxDisplaySurface::vtable24(
-	LPDDSURFACEDESC,
-	MxBitmap*,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4,
-	undefined4
-)
-{
-}
-
 // OFFSET: LEGO1 0x100bacc0 STUB
 MxBool MxDisplaySurface::vtable28(undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4)
-{
-	return 0;
-}
-
-// OFFSET: LEGO1 0x100bc630 STUB
-MxBool MxDisplaySurface::
-	vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
 {
 	return 0;
 }
@@ -253,8 +238,23 @@ undefined4 MxDisplaySurface::vtable44(undefined4, undefined4*, undefined4, undef
 	return 0;
 }
 
-// OFFSET: LEGO1 0x100ba640 STUB
-void MxDisplaySurface::FUN_100ba640()
+// OFFSET: LEGO1 0x100bc200 STUB
+void MxDisplaySurface::vtable24(
+	LPDDSURFACEDESC,
+	MxBitmap*,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4,
+	undefined4
+)
 {
-	// TODO
+}
+
+// OFFSET: LEGO1 0x100bc630 STUB
+MxBool MxDisplaySurface::
+	vtable2c(LPDDSURFACEDESC, MxBitmap*, undefined4, undefined4, undefined4, undefined4, undefined4, undefined4, MxBool)
+{
+	return 0;
 }

--- a/LEGO1/mxdsaction.cpp
+++ b/LEGO1/mxdsaction.cpp
@@ -32,6 +32,36 @@ MxDSAction::MxDSAction()
 	this->m_unkTimingField = INT_MIN;
 }
 
+// OFFSET: LEGO1 0x100ad940
+MxLong MxDSAction::GetDuration()
+{
+	return this->m_duration;
+}
+
+// OFFSET: LEGO1 0x100ad950
+void MxDSAction::SetDuration(MxLong p_duration)
+{
+	this->m_duration = p_duration;
+}
+
+// OFFSET: LEGO1 0x100ad960
+MxBool MxDSAction::HasId(MxU32 p_objectId)
+{
+	return this->GetObjectId() == p_objectId;
+}
+
+// OFFSET: LEGO1 0x100ada40
+void MxDSAction::SetUnkTimingField(MxLong p_unkTimingField)
+{
+	this->m_unkTimingField = p_unkTimingField;
+}
+
+// OFFSET: LEGO1 0x100ada50
+MxLong MxDSAction::GetUnkTimingField()
+{
+	return this->m_unkTimingField;
+}
+
 // OFFSET: LEGO1 0x100ada80
 MxDSAction::~MxDSAction()
 {
@@ -58,17 +88,6 @@ void MxDSAction::CopyFrom(MxDSAction& p_dsAction)
 	this->m_unkTimingField = p_dsAction.m_unkTimingField;
 }
 
-// OFFSET: LEGO1 0x100adc10
-MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
-{
-	if (this == &p_dsAction)
-		return *this;
-
-	MxDSObject::operator=(p_dsAction);
-	this->CopyFrom(p_dsAction);
-	return *this;
-}
-
 // OFFSET: LEGO1 0x100adbe0
 MxU32 MxDSAction::GetSizeOnDisk()
 {
@@ -80,42 +99,15 @@ MxU32 MxDSAction::GetSizeOnDisk()
 	return totalSizeOnDisk;
 }
 
-// OFFSET: LEGO1 0x100adf70
-void MxDSAction::Deserialize(char** p_source, MxS16 p_unk24)
+// OFFSET: LEGO1 0x100adc10
+MxDSAction& MxDSAction::operator=(MxDSAction& p_dsAction)
 {
-	MxDSObject::Deserialize(p_source, p_unk24);
+	if (this == &p_dsAction)
+		return *this;
 
-	GetScalar(p_source, this->m_flags);
-	GetScalar(p_source, this->m_startTime);
-	GetScalar(p_source, this->m_duration);
-	GetScalar(p_source, this->m_loopCount);
-	GetDouble(p_source, this->m_location[0]);
-	GetDouble(p_source, this->m_location[1]);
-	GetDouble(p_source, this->m_location[2]);
-	GetDouble(p_source, this->m_direction[0]);
-	GetDouble(p_source, this->m_direction[1]);
-	GetDouble(p_source, this->m_direction[2]);
-	GetDouble(p_source, this->m_up[0]);
-	GetDouble(p_source, this->m_up[1]);
-	GetDouble(p_source, this->m_up[2]);
-
-	MxU16 extraLength = GetScalar((MxU16**) p_source);
-	if (extraLength) {
-		AppendData(extraLength, *p_source);
-		*p_source += extraLength;
-	}
-}
-
-// OFFSET: LEGO1 0x100ad940
-MxLong MxDSAction::GetDuration()
-{
-	return this->m_duration;
-}
-
-// OFFSET: LEGO1 0x100ad950
-void MxDSAction::SetDuration(MxLong p_duration)
-{
-	this->m_duration = p_duration;
+	MxDSObject::operator=(p_dsAction);
+	this->CopyFrom(p_dsAction);
+	return *this;
 }
 
 // OFFSET: LEGO1 0x100adc40
@@ -127,6 +119,12 @@ MxDSAction* MxDSAction::Clone()
 		*clone = *this;
 
 	return clone;
+}
+
+// OFFSET: LEGO1 0x100adcd0
+MxLong MxDSAction::GetElapsedTime()
+{
+	return Timer()->GetTime() - this->m_unkTimingField;
 }
 
 // OFFSET: LEGO1 0x100add00
@@ -178,30 +176,6 @@ void MxDSAction::MergeFrom(MxDSAction& p_dsAction)
 	}
 }
 
-// OFFSET: LEGO1 0x100ad960
-MxBool MxDSAction::HasId(MxU32 p_objectId)
-{
-	return this->GetObjectId() == p_objectId;
-}
-
-// OFFSET: LEGO1 0x100ada40
-void MxDSAction::SetUnkTimingField(MxLong p_unkTimingField)
-{
-	this->m_unkTimingField = p_unkTimingField;
-}
-
-// OFFSET: LEGO1 0x100ada50
-MxLong MxDSAction::GetUnkTimingField()
-{
-	return this->m_unkTimingField;
-}
-
-// OFFSET: LEGO1 0x100adcd0
-MxLong MxDSAction::GetElapsedTime()
-{
-	return Timer()->GetTime() - this->m_unkTimingField;
-}
-
 // OFFSET: LEGO1 0x100ade60
 void MxDSAction::AppendData(MxU16 p_extraLength, const char* p_extraData)
 {
@@ -227,5 +201,31 @@ void MxDSAction::AppendData(MxU16 p_extraLength, const char* p_extraData)
 			this->m_extraLength = p_extraLength;
 			memcpy(copy, p_extraData, p_extraLength);
 		}
+	}
+}
+
+// OFFSET: LEGO1 0x100adf70
+void MxDSAction::Deserialize(char** p_source, MxS16 p_unk24)
+{
+	MxDSObject::Deserialize(p_source, p_unk24);
+
+	GetScalar(p_source, this->m_flags);
+	GetScalar(p_source, this->m_startTime);
+	GetScalar(p_source, this->m_duration);
+	GetScalar(p_source, this->m_loopCount);
+	GetDouble(p_source, this->m_location[0]);
+	GetDouble(p_source, this->m_location[1]);
+	GetDouble(p_source, this->m_location[2]);
+	GetDouble(p_source, this->m_direction[0]);
+	GetDouble(p_source, this->m_direction[1]);
+	GetDouble(p_source, this->m_direction[2]);
+	GetDouble(p_source, this->m_up[0]);
+	GetDouble(p_source, this->m_up[1]);
+	GetDouble(p_source, this->m_up[2]);
+
+	MxU16 extraLength = GetScalar((MxU16**) p_source);
+	if (extraLength) {
+		AppendData(extraLength, *p_source);
+		*p_source += extraLength;
 	}
 }

--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -5,17 +5,17 @@
 #define SI_MAJOR_VERSION 2
 #define SI_MINOR_VERSION 2
 
+// OFFSET: LEGO1 0x100bfed0
+MxDSFile::~MxDSFile()
+{
+	Close();
+}
+
 // OFFSET: LEGO1 0x100cc4b0
 MxDSFile::MxDSFile(const char* filename, MxULong skipReadingChunks)
 {
 	m_filename = filename;
 	m_skipReadingChunks = skipReadingChunks;
-}
-
-// OFFSET: LEGO1 0x100bfed0
-MxDSFile::~MxDSFile()
-{
-	Close();
 }
 
 // OFFSET: LEGO1 0x100cc590
@@ -44,16 +44,6 @@ MxLong MxDSFile::Open(MxULong uStyle)
 	}
 
 	return longResult;
-}
-
-// OFFSET: LEGO1 0x100cc780
-MxResult MxDSFile::Read(unsigned char* p_buf, MxULong p_nbytes)
-{
-	if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
-		return FAILURE;
-
-	m_position += p_nbytes;
-	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100cc620
@@ -91,6 +81,30 @@ MxLong MxDSFile::ReadChunks()
 	}
 }
 
+// OFFSET: LEGO1 0x100cc740
+MxLong MxDSFile::Close()
+{
+	m_io.Close(0);
+	m_position = -1;
+	memset(&m_header, 0, sizeof(m_header));
+	if (m_lengthInDWords != 0) {
+		m_lengthInDWords = 0;
+		delete[] m_pBuffer;
+		m_pBuffer = NULL;
+	}
+	return 0;
+}
+
+// OFFSET: LEGO1 0x100cc780
+MxResult MxDSFile::Read(unsigned char* p_buf, MxULong p_nbytes)
+{
+	if (m_io.Read(p_buf, p_nbytes) != p_nbytes)
+		return FAILURE;
+
+	m_position += p_nbytes;
+	return SUCCESS;
+}
+
 // OFFSET: LEGO1 0x100cc7b0
 MxLong MxDSFile::Seek(MxLong lOffset, int iOrigin)
 {
@@ -107,18 +121,4 @@ MxULong MxDSFile::GetBufferSize()
 MxULong MxDSFile::GetStreamBuffersNum()
 {
 	return m_header.streamBuffersNum;
-}
-
-// OFFSET: LEGO1 0x100cc740
-MxLong MxDSFile::Close()
-{
-	m_io.Close(0);
-	m_position = -1;
-	memset(&m_header, 0, sizeof(m_header));
-	if (m_lengthInDWords != 0) {
-		m_lengthInDWords = 0;
-		delete[] m_pBuffer;
-		m_pBuffer = NULL;
-	}
-	return 0;
 }

--- a/LEGO1/mxdsmediaaction.cpp
+++ b/LEGO1/mxdsmediaaction.cpp
@@ -47,6 +47,23 @@ MxDSMediaAction& MxDSMediaAction::operator=(MxDSMediaAction& p_dsMediaAction)
 	return *this;
 }
 
+// OFFSET: LEGO1 0x100c8e80
+void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
+{
+	if (this->m_mediaSrcPath == p_mediaSrcPath)
+		return;
+
+	delete[] this->m_mediaSrcPath;
+
+	if (p_mediaSrcPath) {
+		this->m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
+		if (this->m_mediaSrcPath)
+			strcpy(this->m_mediaSrcPath, p_mediaSrcPath);
+	}
+	else
+		this->m_mediaSrcPath = NULL;
+}
+
 // OFFSET: LEGO1 0x100c8f10
 MxU32 MxDSMediaAction::GetSizeOnDisk()
 {
@@ -74,21 +91,4 @@ void MxDSMediaAction::Deserialize(char** p_source, MxS16 p_unk24)
 	GetScalar(p_source, this->m_mediaFormat);
 	GetScalar(p_source, this->m_paletteManagement);
 	GetScalar(p_source, this->m_sustainTime);
-}
-
-// OFFSET: LEGO1 0x100c8e80
-void MxDSMediaAction::CopyMediaSrcPath(const char* p_mediaSrcPath)
-{
-	if (this->m_mediaSrcPath == p_mediaSrcPath)
-		return;
-
-	delete[] this->m_mediaSrcPath;
-
-	if (p_mediaSrcPath) {
-		this->m_mediaSrcPath = new char[strlen(p_mediaSrcPath) + 1];
-		if (this->m_mediaSrcPath)
-			strcpy(this->m_mediaSrcPath, p_mediaSrcPath);
-	}
-	else
-		this->m_mediaSrcPath = NULL;
 }

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -6,7 +6,7 @@
 #include "mxcore.h"
 #include "mxdstypes.h"
 
-// TODO: Find proper compilation unit to place this
+// TODO: Find proper compilation unit to put this
 // OFFSET: LEGO1 0x10005530 TEMPLATE
 // MxDSObject::SetAtomId
 

--- a/LEGO1/mxdsobject.h
+++ b/LEGO1/mxdsobject.h
@@ -6,6 +6,10 @@
 #include "mxcore.h"
 #include "mxdstypes.h"
 
+// TODO: Find proper compilation unit to place this
+// OFFSET: LEGO1 0x10005530 TEMPLATE
+// MxDSObject::SetAtomId
+
 // VTABLE 0x100dc868
 // SIZE 0x2c
 class MxDSObject : public MxCore {
@@ -28,11 +32,9 @@ public:
 		return !strcmp(name, MxDSObject::ClassName()) || MxCore::IsA(name);
 	}; // vtable+10;
 
-	virtual undefined4 unk14();                               // vtable+14;
-	virtual MxU32 GetSizeOnDisk();                            // vtable+18;
-	virtual void Deserialize(char** p_source, MxS16 p_unk24); // vtable+1c;
-	// OFFSET: ISLE 0x401c40
-	// OFFSET: LEGO1 0x10005530
+	virtual undefined4 unk14();                                                     // vtable+14;
+	virtual MxU32 GetSizeOnDisk();                                                  // vtable+18;
+	virtual void Deserialize(char** p_source, MxS16 p_unk24);                       // vtable+1c;
 	inline virtual void SetAtomId(MxAtomId p_atomId) { this->m_atomId = p_atomId; } // vtable+20;
 
 	inline const MxAtomId& GetAtomId() { return this->m_atomId; }

--- a/LEGO1/mxdssound.cpp
+++ b/LEGO1/mxdssound.cpp
@@ -34,13 +34,15 @@ MxDSSound& MxDSSound::operator=(MxDSSound& p_dsSound)
 	return *this;
 }
 
-// OFFSET: LEGO1 0x100c95d0
-MxU32 MxDSSound::GetSizeOnDisk()
+// OFFSET: LEGO1 0x100c9510
+MxDSAction* MxDSSound::Clone()
 {
-	MxU32 totalSizeOnDisk = MxDSMediaAction::GetSizeOnDisk();
+	MxDSSound* clone = new MxDSSound();
 
-	this->m_sizeOnDisk = sizeof(this->m_volume);
-	return totalSizeOnDisk + 4;
+	if (clone)
+		*clone = *this;
+
+	return clone;
 }
 
 // OFFSET: LEGO1 0x100c95a0
@@ -51,13 +53,11 @@ void MxDSSound::Deserialize(char** p_source, MxS16 p_unk24)
 	GetScalar(p_source, this->m_volume);
 }
 
-// OFFSET: LEGO1 0x100c9510
-MxDSAction* MxDSSound::Clone()
+// OFFSET: LEGO1 0x100c95d0
+MxU32 MxDSSound::GetSizeOnDisk()
 {
-	MxDSSound* clone = new MxDSSound();
+	MxU32 totalSizeOnDisk = MxDSMediaAction::GetSizeOnDisk();
 
-	if (clone)
-		*clone = *this;
-
-	return clone;
+	this->m_sizeOnDisk = sizeof(this->m_volume);
+	return totalSizeOnDisk + 4;
 }

--- a/LEGO1/mxdsstreamingaction.cpp
+++ b/LEGO1/mxdsstreamingaction.cpp
@@ -14,6 +14,14 @@ MxDSStreamingAction::MxDSStreamingAction(MxDSAction& p_dsAction, MxU32 p_offset)
 	this->m_bufferOffset = p_offset;
 }
 
+// OFFSET: LEGO1 0x100cd090
+MxBool MxDSStreamingAction::HasId(MxU32 p_objectId)
+{
+	if (this->m_internalAction)
+		return this->m_internalAction->HasId(p_objectId);
+	return FALSE;
+}
+
 // OFFSET: LEGO1 0x100cd0d0
 MxDSStreamingAction::MxDSStreamingAction(MxDSStreamingAction& p_dsStreamingAction)
 {
@@ -32,6 +40,20 @@ MxDSStreamingAction::~MxDSStreamingAction()
 		delete this->m_internalAction;
 }
 
+// OFFSET: LEGO1 0x100cd1e0
+MxResult MxDSStreamingAction::Init()
+{
+	this->m_unk94 = 0;
+	this->m_bufferOffset = 0;
+	this->m_unk9c = 0;
+	this->m_unka0 = NULL;
+	this->m_unka4 = NULL;
+	this->m_unka8 = 0;
+	this->m_unkac = 2;
+	this->m_internalAction = NULL;
+	return SUCCESS;
+}
+
 // OFFSET: LEGO1 0x100cd220
 MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStreamingAction)
 {
@@ -46,28 +68,6 @@ MxDSStreamingAction* MxDSStreamingAction::CopyFrom(MxDSStreamingAction& p_dsStre
 	SetInternalAction(p_dsStreamingAction.m_internalAction ? p_dsStreamingAction.m_internalAction->Clone() : NULL);
 
 	return this;
-}
-
-// OFFSET: LEGO1 0x100cd090
-MxBool MxDSStreamingAction::HasId(MxU32 p_objectId)
-{
-	if (this->m_internalAction)
-		return this->m_internalAction->HasId(p_objectId);
-	return FALSE;
-}
-
-// OFFSET: LEGO1 0x100cd1e0
-MxResult MxDSStreamingAction::Init()
-{
-	this->m_unk94 = 0;
-	this->m_bufferOffset = 0;
-	this->m_unk9c = 0;
-	this->m_unka0 = NULL;
-	this->m_unka4 = NULL;
-	this->m_unka8 = 0;
-	this->m_unkac = 2;
-	this->m_internalAction = NULL;
-	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100cd2a0

--- a/LEGO1/mxentity.cpp
+++ b/LEGO1/mxentity.cpp
@@ -2,10 +2,12 @@
 
 DECOMP_SIZE_ASSERT(MxEntity, 0x10)
 
-// OFFSET: LEGO1 0x1001d190
-MxEntity::MxEntity()
+// OFFSET: LEGO1 0x10001070
+MxResult MxEntity::Create(MxS32 p_id, const MxAtomId& p_atom)
 {
-	this->m_mxEntityId = -1;
+	this->m_mxEntityId = p_id;
+	this->m_atom = p_atom;
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x1000c110
@@ -13,10 +15,8 @@ MxEntity::~MxEntity()
 {
 }
 
-// OFFSET: LEGO1 0x10001070
-MxResult MxEntity::Create(MxS32 p_id, const MxAtomId& p_atom)
+// OFFSET: LEGO1 0x1001d190
+MxEntity::MxEntity()
 {
-	this->m_mxEntityId = p_id;
-	this->m_atom = p_atom;
-	return SUCCESS;
+	this->m_mxEntityId = -1;
 }

--- a/LEGO1/mxflcpresenter.h
+++ b/LEGO1/mxflcpresenter.h
@@ -11,17 +11,17 @@ public:
 	MxFlcPresenter();
 	virtual ~MxFlcPresenter() override;
 
+	// OFFSET: LEGO1 0x1004e200
+	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
+	{
+		return !strcmp(name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(name);
+	}
+
 	// OFFSET: LEGO1 0x100b33f0
 	inline virtual const char* ClassName() const override // vtable+0xc
 	{
 		// 0x100f43c8
 		return "MxFlcPresenter";
-	}
-
-	// OFFSET: LEGO1 0x1004e200
-	inline virtual MxBool IsA(const char* name) const override // vtable+0x10
-	{
-		return !strcmp(name, MxFlcPresenter::ClassName()) || MxVideoPresenter::IsA(name);
 	}
 
 	virtual void VTable0x70() override; // vtable+0x70

--- a/LEGO1/mxmediamanager.cpp
+++ b/LEGO1/mxmediamanager.cpp
@@ -28,24 +28,6 @@ MxResult MxMediaManager::Init()
 	return SUCCESS;
 }
 
-// OFFSET: LEGO1 0x100b8790
-MxResult MxMediaManager::Tickle()
-{
-	MxAutoLocker lock(&this->m_criticalSection);
-	MxPresenter* presenter;
-	MxPresenterListCursor cursor(this->m_presenters);
-
-	while (cursor.Next(presenter))
-		presenter->Tickle();
-
-	cursor.Reset();
-
-	while (cursor.Next(presenter))
-		presenter->PutData();
-
-	return SUCCESS;
-}
-
 // OFFSET: LEGO1 0x100b85e0
 MxResult MxMediaManager::InitPresenters()
 {
@@ -70,6 +52,24 @@ void MxMediaManager::Destroy()
 		delete this->m_presenters;
 
 	Init();
+}
+
+// OFFSET: LEGO1 0x100b8790
+MxResult MxMediaManager::Tickle()
+{
+	MxAutoLocker lock(&this->m_criticalSection);
+	MxPresenter* presenter;
+	MxPresenterListCursor cursor(this->m_presenters);
+
+	while (cursor.Next(presenter))
+		presenter->Tickle();
+
+	cursor.Reset();
+
+	while (cursor.Next(presenter))
+		presenter->PutData();
+
+	return SUCCESS;
 }
 
 // OFFSET: LEGO1 0x100b88c0

--- a/LEGO1/mxmusicmanager.cpp
+++ b/LEGO1/mxmusicmanager.cpp
@@ -19,24 +19,6 @@ MxMusicManager::~MxMusicManager()
 	Destroy(TRUE);
 }
 
-// OFFSET: LEGO1 0x100c0b20
-void MxMusicManager::DeinitializeMIDI()
-{
-	m_criticalSection.Enter();
-
-	if (m_MIDIInitialized) {
-		m_MIDIInitialized = FALSE;
-		midiStreamStop(m_MIDIStreamH);
-		midiOutUnprepareHeader((HMIDIOUT) m_MIDIStreamH, m_MIDIHdrP, sizeof(MIDIHDR));
-		midiOutSetVolume((HMIDIOUT) m_MIDIStreamH, m_MIDIVolume);
-		midiStreamClose(m_MIDIStreamH);
-		delete m_MIDIHdrP;
-		InitData();
-	}
-
-	m_criticalSection.Leave();
-}
-
 // OFFSET: LEGO1 0x100c0690
 void MxMusicManager::Init()
 {
@@ -80,19 +62,6 @@ void MxMusicManager::Destroy(MxBool p_fromDestructor)
 	}
 }
 
-// OFFSET: LEGO1 0x100c0930
-void MxMusicManager::Destroy()
-{
-	Destroy(FALSE);
-}
-
-// OFFSET: LEGO1 0x100c09a0
-MxS32 MxMusicManager::CalculateVolume(MxS32 p_volume)
-{
-	MxS32 result = (p_volume * 0xffff) / 100;
-	return (result << 0x10) | result;
-}
-
 // OFFSET: LEGO1 0x100c07f0
 void MxMusicManager::SetMIDIVolume()
 {
@@ -103,15 +72,6 @@ void MxMusicManager::SetMIDIVolume()
 		MxS32 volume = CalculateVolume(result);
 		midiOutSetVolume((HMIDIOUT) streamHandle, volume);
 	}
-}
-
-// OFFSET: LEGO1 0x100c0940
-void MxMusicManager::SetVolume(MxS32 p_volume)
-{
-	MxAudioManager::SetVolume(p_volume);
-	m_criticalSection.Enter();
-	SetMIDIVolume();
-	m_criticalSection.Leave();
 }
 
 // OFFSET: LEGO1 0x100c0840
@@ -143,4 +103,44 @@ done:
 		m_criticalSection.Leave();
 
 	return status;
+}
+
+// OFFSET: LEGO1 0x100c0930
+void MxMusicManager::Destroy()
+{
+	Destroy(FALSE);
+}
+
+// OFFSET: LEGO1 0x100c0940
+void MxMusicManager::SetVolume(MxS32 p_volume)
+{
+	MxAudioManager::SetVolume(p_volume);
+	m_criticalSection.Enter();
+	SetMIDIVolume();
+	m_criticalSection.Leave();
+}
+
+// OFFSET: LEGO1 0x100c09a0
+MxS32 MxMusicManager::CalculateVolume(MxS32 p_volume)
+{
+	MxS32 result = (p_volume * 0xffff) / 100;
+	return (result << 0x10) | result;
+}
+
+// OFFSET: LEGO1 0x100c0b20
+void MxMusicManager::DeinitializeMIDI()
+{
+	m_criticalSection.Enter();
+
+	if (m_MIDIInitialized) {
+		m_MIDIInitialized = FALSE;
+		midiStreamStop(m_MIDIStreamH);
+		midiOutUnprepareHeader((HMIDIOUT) m_MIDIStreamH, m_MIDIHdrP, sizeof(MIDIHDR));
+		midiOutSetVolume((HMIDIOUT) m_MIDIStreamH, m_MIDIVolume);
+		midiStreamClose(m_MIDIStreamH);
+		delete m_MIDIHdrP;
+		InitData();
+	}
+
+	m_criticalSection.Leave();
 }

--- a/LEGO1/mxomni.cpp
+++ b/LEGO1/mxomni.cpp
@@ -25,10 +25,113 @@ MxBool g_use3dSound;
 // 0x101015b0
 MxOmni* MxOmni::g_instance = NULL;
 
+// OFFSET: LEGO1 0x100159e0
+void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last)
+{
+	MxDSAction action;
+
+	action.SetAtomId(*p_id);
+	action.SetUnknown24(-2);
+
+	for (MxS32 l_first = p_first, l_last = p_last; l_first <= l_last; l_first++) {
+		action.SetObjectId(l_first);
+		DeleteObject(action);
+	}
+}
+
+// OFFSET: LEGO1 0x10058a90
+MxBool MxOmni::IsTimerRunning()
+{
+	return m_timerRunning;
+}
+
+// OFFSET: LEGO1 0x100acea0
+MxObjectFactory* ObjectFactory()
+{
+	return MxOmni::GetInstance()->GetObjectFactory();
+}
+
+// OFFSET: LEGO1 0x100aceb0
+MxNotificationManager* NotificationManager()
+{
+	return MxOmni::GetInstance()->GetNotificationManager();
+}
+
+// OFFSET: LEGO1 0x100acec0
+MxTickleManager* TickleManager()
+{
+	return MxOmni::GetInstance()->GetTickleManager();
+}
+
+// OFFSET: LEGO1 0x100aced0
+MxTimer* Timer()
+{
+	return MxOmni::GetInstance()->GetTimer();
+}
+
+// OFFSET: LEGO1 0x100acee0
+MxAtomIdCounterSet* AtomIdCounterSet()
+{
+	return MxOmni::GetInstance()->GetAtomIdCounterSet();
+}
+
+// OFFSET: LEGO1 0x100acef0
+MxStreamer* Streamer()
+{
+	return MxOmni::GetInstance()->GetStreamer();
+}
+
+// OFFSET: LEGO1 0x100acf00
+MxSoundManager* MSoundManager()
+{
+	return MxOmni::GetInstance()->GetSoundManager();
+}
+
+// OFFSET: LEGO1 0x100acf10
+MxVideoManager* MVideoManager()
+{
+	return MxOmni::GetInstance()->GetVideoManager();
+}
+
+// OFFSET: LEGO1 0x100acf20
+MxVariableTable* VariableTable()
+{
+	return MxOmni::GetInstance()->GetVariableTable();
+}
+
+// OFFSET: LEGO1 0x100acf30
+MxMusicManager* MusicManager()
+{
+	return MxOmni::GetInstance()->GetMusicManager();
+}
+
+// OFFSET: LEGO1 0x100acf40
+MxEventManager* EventManager()
+{
+	return MxOmni::GetInstance()->GetEventManager();
+}
+
+// OFFSET: LEGO1 0x100acf70
+MxResult DeleteObject(MxDSAction& p_dsAction)
+{
+	return MxOmni::GetInstance()->DeleteObject(p_dsAction);
+}
+
 // OFFSET: LEGO1 0x100aef10
 MxOmni::MxOmni()
 {
 	Init();
+}
+
+// OFFSET: LEGO1 0x100aefb0
+MxEntity* MxOmni::FindWorld(const char*, MxS32, MxPresenter*)
+{
+	return NULL;
+}
+
+// OFFSET: LEGO1 0x100aefc0
+void MxOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
+{
 }
 
 // OFFSET: LEGO1 0x100aeff0
@@ -53,130 +156,6 @@ void MxOmni::Init()
 	m_streamer = NULL;
 	m_atomIdCounterSet = NULL;
 	m_timerRunning = NULL;
-}
-
-// OFFSET: LEGO1 0x100b0090
-MxResult MxOmni::Start(MxDSAction* p_dsAction)
-{
-	MxResult result = FAILURE;
-	if (p_dsAction->GetAtomId().GetInternal() != NULL && p_dsAction->GetObjectId() != -1 && m_streamer != NULL) {
-		result = m_streamer->FUN_100b99b0(p_dsAction);
-	}
-
-	return result;
-}
-
-// OFFSET: LEGO1 0x100b00c0 STUB
-MxResult MxOmni::DeleteObject(MxDSAction& p_dsAction)
-{
-	// TODO
-	return FAILURE;
-}
-
-// OFFSET: LEGO1 0x100b09a0
-MxBool MxOmni::DoesEntityExist(MxDSAction& p_dsAction)
-{
-	if (m_streamer->FUN_100b9b30(p_dsAction)) {
-		MxNotificationPtrList* queue = m_notificationManager->GetQueue();
-
-		if (!queue || queue->size() == 0)
-			return TRUE;
-	}
-	return FALSE;
-}
-
-// OFFSET: LEGO1 0x100b00e0 STUB
-void MxOmni::Vtable0x2c()
-{
-	// TODO
-}
-
-// OFFSET: LEGO1 0x100aefb0
-MxEntity* MxOmni::FindWorld(const char*, MxS32, MxPresenter*)
-{
-	return NULL;
-}
-
-// OFFSET: LEGO1 0x100aefc0
-void MxOmni::NotifyCurrentEntity(MxNotificationParam* p_param)
-{
-}
-
-// OFFSET: LEGO1 0x100b09d0
-void MxOmni::StartTimer()
-{
-	if (m_timerRunning == FALSE && m_timer != NULL && m_soundManager != NULL) {
-		m_timer->Start();
-		m_soundManager->vtable0x34();
-		m_timerRunning = TRUE;
-	}
-}
-
-// OFFSET: LEGO1 0x100b0a00
-void MxOmni::StopTimer()
-{
-	if (m_timerRunning != FALSE && m_timer != NULL && m_soundManager != NULL) {
-		m_timer->Stop();
-		m_soundManager->vtable0x38();
-		m_timerRunning = FALSE;
-	}
-}
-
-// OFFSET: LEGO1 0x10058a90
-MxBool MxOmni::IsTimerRunning()
-{
-	return m_timerRunning;
-}
-
-// OFFSET: LEGO1 0x100b0690
-void MxOmni::DestroyInstance()
-{
-	if (g_instance != NULL) {
-		delete g_instance;
-		g_instance = NULL;
-	}
-}
-
-// OFFSET: LEGO1 0x100b0900
-const char* MxOmni::GetHD()
-{
-	return g_hdPath;
-}
-
-// OFFSET: LEGO1 0x100b0940
-const char* MxOmni::GetCD()
-{
-	return g_cdPath;
-}
-
-// OFFSET: LEGO1 0x100b0980
-MxBool MxOmni::IsSound3D()
-{
-	return g_use3dSound;
-}
-
-// OFFSET: LEGO1 0x100b0910
-void MxOmni::SetHD(const char* p_hd)
-{
-	strcpy(g_hdPath, p_hd);
-}
-
-// OFFSET: LEGO1 0x100b0950
-void MxOmni::SetCD(const char* p_cd)
-{
-	strcpy(g_cdPath, p_cd);
-}
-
-// OFFSET: LEGO1 0x100b0990
-void MxOmni::SetSound3D(MxBool p_3dsound)
-{
-	g_use3dSound = p_3dsound;
-}
-
-// OFFSET: LEGO1 0x100b0680
-MxOmni* MxOmni::GetInstance()
-{
-	return g_instance;
 }
 
 // OFFSET: LEGO1 0x100af0b0
@@ -320,6 +299,45 @@ void MxOmni::Destroy()
 	Init();
 }
 
+// OFFSET: LEGO1 0x100b0090
+MxResult MxOmni::Start(MxDSAction* p_dsAction)
+{
+	MxResult result = FAILURE;
+	if (p_dsAction->GetAtomId().GetInternal() != NULL && p_dsAction->GetObjectId() != -1 && m_streamer != NULL) {
+		result = m_streamer->FUN_100b99b0(p_dsAction);
+	}
+
+	return result;
+}
+
+// OFFSET: LEGO1 0x100b00c0 STUB
+MxResult MxOmni::DeleteObject(MxDSAction& p_dsAction)
+{
+	// TODO
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100b00e0 STUB
+void MxOmni::Vtable0x2c()
+{
+	// TODO
+}
+
+// OFFSET: LEGO1 0x100b0680
+MxOmni* MxOmni::GetInstance()
+{
+	return g_instance;
+}
+
+// OFFSET: LEGO1 0x100b0690
+void MxOmni::DestroyInstance()
+{
+	if (g_instance != NULL) {
+		delete g_instance;
+		g_instance = NULL;
+	}
+}
+
 // OFFSET: LEGO1 0x100b07f0
 MxLong MxOmni::Notify(MxParam& p)
 {
@@ -338,88 +356,70 @@ MxResult MxOmni::HandleNotificationType2(MxParam& p_param)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100acea0
-MxObjectFactory* ObjectFactory()
+// OFFSET: LEGO1 0x100b0900
+const char* MxOmni::GetHD()
 {
-	return MxOmni::GetInstance()->GetObjectFactory();
+	return g_hdPath;
 }
 
-// OFFSET: LEGO1 0x100aceb0
-MxNotificationManager* NotificationManager()
+// OFFSET: LEGO1 0x100b0910
+void MxOmni::SetHD(const char* p_hd)
 {
-	return MxOmni::GetInstance()->GetNotificationManager();
+	strcpy(g_hdPath, p_hd);
 }
 
-// OFFSET: LEGO1 0x100acec0
-MxTickleManager* TickleManager()
+// OFFSET: LEGO1 0x100b0940
+const char* MxOmni::GetCD()
 {
-	return MxOmni::GetInstance()->GetTickleManager();
+	return g_cdPath;
 }
 
-// OFFSET: LEGO1 0x100aced0
-MxTimer* Timer()
+// OFFSET: LEGO1 0x100b0950
+void MxOmni::SetCD(const char* p_cd)
 {
-	return MxOmni::GetInstance()->GetTimer();
+	strcpy(g_cdPath, p_cd);
 }
 
-// OFFSET: LEGO1 0x100acee0
-MxAtomIdCounterSet* AtomIdCounterSet()
+// OFFSET: LEGO1 0x100b0980
+MxBool MxOmni::IsSound3D()
 {
-	return MxOmni::GetInstance()->GetAtomIdCounterSet();
+	return g_use3dSound;
 }
 
-// OFFSET: LEGO1 0x100acef0
-MxStreamer* Streamer()
+// OFFSET: LEGO1 0x100b0990
+void MxOmni::SetSound3D(MxBool p_3dsound)
 {
-	return MxOmni::GetInstance()->GetStreamer();
+	g_use3dSound = p_3dsound;
 }
 
-// OFFSET: LEGO1 0x100acf00
-MxSoundManager* MSoundManager()
+// OFFSET: LEGO1 0x100b09a0
+MxBool MxOmni::DoesEntityExist(MxDSAction& p_dsAction)
 {
-	return MxOmni::GetInstance()->GetSoundManager();
+	if (m_streamer->FUN_100b9b30(p_dsAction)) {
+		MxNotificationPtrList* queue = m_notificationManager->GetQueue();
+
+		if (!queue || queue->size() == 0)
+			return TRUE;
+	}
+	return FALSE;
 }
 
-// OFFSET: LEGO1 0x100acf10
-MxVideoManager* MVideoManager()
+// OFFSET: LEGO1 0x100b09d0
+void MxOmni::StartTimer()
 {
-	return MxOmni::GetInstance()->GetVideoManager();
+	if (m_timerRunning == FALSE && m_timer != NULL && m_soundManager != NULL) {
+		m_timer->Start();
+		m_soundManager->vtable0x34();
+		m_timerRunning = TRUE;
+	}
 }
 
-// OFFSET: LEGO1 0x100acf20
-MxVariableTable* VariableTable()
+// OFFSET: LEGO1 0x100b0a00
+void MxOmni::StopTimer()
 {
-	return MxOmni::GetInstance()->GetVariableTable();
-}
-
-// OFFSET: LEGO1 0x100acf30
-MxMusicManager* MusicManager()
-{
-	return MxOmni::GetInstance()->GetMusicManager();
-}
-
-// OFFSET: LEGO1 0x100acf40
-MxEventManager* EventManager()
-{
-	return MxOmni::GetInstance()->GetEventManager();
-}
-
-// OFFSET: LEGO1 0x100acf70
-MxResult DeleteObject(MxDSAction& p_dsAction)
-{
-	return MxOmni::GetInstance()->DeleteObject(p_dsAction);
-}
-
-// OFFSET: LEGO1 0x100159e0
-void DeleteObjects(MxAtomId* p_id, MxS32 p_first, MxS32 p_last)
-{
-	MxDSAction action;
-
-	action.SetAtomId(*p_id);
-	action.SetUnknown24(-2);
-
-	for (MxS32 l_first = p_first, l_last = p_last; l_first <= l_last; l_first++) {
-		action.SetObjectId(l_first);
-		DeleteObject(action);
+	if (m_timerRunning != FALSE && m_timer != NULL && m_soundManager != NULL) {
+		m_timer->Stop();
+		m_soundManager->vtable0x38();
+		m_timerRunning = FALSE;
 	}
 }

--- a/LEGO1/mxramstreamcontroller.cpp
+++ b/LEGO1/mxramstreamcontroller.cpp
@@ -5,11 +5,7 @@
 
 DECOMP_SIZE_ASSERT(MxRAMStreamController, 0x98);
 
-// OFFSET: LEGO1 0x100d0d80 STUB
-undefined* __cdecl FUN_100d0d80(MxU32* p_fileSizeBuffer, MxU32 p_fileSize)
-{
-	return NULL;
-}
+undefined* __cdecl FUN_100d0d80(MxU32* p_fileSizeBuffer, MxU32 p_fileSize);
 
 // OFFSET: LEGO1 0x100c6110
 MxResult MxRAMStreamController::Open(const char* p_filename)
@@ -51,4 +47,10 @@ MxResult MxRAMStreamController::vtable0x24(undefined4 p_unknown)
 {
 	// TODO STUB
 	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100d0d80 STUB
+undefined* __cdecl FUN_100d0d80(MxU32* p_fileSizeBuffer, MxU32 p_fileSize)
+{
+	return NULL;
 }

--- a/LEGO1/mxramstreamprovider.cpp
+++ b/LEGO1/mxramstreamprovider.cpp
@@ -14,27 +14,6 @@ MxRAMStreamProvider::MxRAMStreamProvider()
 	m_bufferForDWords = NULL;
 }
 
-// OFFSET: LEGO1 0x100d0a50
-MxRAMStreamProvider::~MxRAMStreamProvider()
-{
-	m_bufferSize = 0;
-	m_fileSize = 0;
-
-	free(m_pBufferOfFileSize);
-	m_pBufferOfFileSize = NULL;
-
-	m_lengthInDWords = 0;
-
-	free(m_bufferForDWords);
-	m_bufferForDWords = NULL;
-}
-
-// OFFSET: LEGO1 0x100d0ae0 STUB
-MxResult MxRAMStreamProvider::SetResourceToGet(MxStreamController* p_resource)
-{
-	return FAILURE;
-}
-
 // OFFSET: LEGO1 0x100d0930
 MxU32 MxRAMStreamProvider::GetFileSize()
 {
@@ -57,4 +36,25 @@ MxU32 MxRAMStreamProvider::GetLengthInDWords()
 MxU32* MxRAMStreamProvider::GetBufferForDWords()
 {
 	return m_bufferForDWords;
+}
+
+// OFFSET: LEGO1 0x100d0a50
+MxRAMStreamProvider::~MxRAMStreamProvider()
+{
+	m_bufferSize = 0;
+	m_fileSize = 0;
+
+	free(m_pBufferOfFileSize);
+	m_pBufferOfFileSize = NULL;
+
+	m_lengthInDWords = 0;
+
+	free(m_bufferForDWords);
+	m_bufferForDWords = NULL;
+}
+
+// OFFSET: LEGO1 0x100d0ae0 STUB
+MxResult MxRAMStreamProvider::SetResourceToGet(MxStreamController* p_resource)
+{
+	return FAILURE;
 }

--- a/LEGO1/mxregionlist.cpp
+++ b/LEGO1/mxregionlist.cpp
@@ -2,6 +2,12 @@
 
 #include "mxregion.h"
 
+// OFFSET: LEGO1 0x100c32e0 TEMPLATE
+// MxCollection<MxRegionTopBottom *>::Compare
+
+// OFFSET: LEGO1 0x100c3340 TEMPLATE
+// MxCollection<MxRegionTopBottom *>::Destroy
+
 // OFFSET: LEGO1 0x100c33e0
 void MxRegionList::Destroy(MxRegionTopBottom* p_topBottom)
 {
@@ -11,18 +17,6 @@ void MxRegionList::Destroy(MxRegionTopBottom* p_topBottom)
 		delete p_topBottom;
 	}
 }
-
-// OFFSET: LEGO1 0x100c4e80
-void MxRegionLeftRightList::Destroy(MxRegionLeftRight* p_leftRight)
-{
-	delete p_leftRight;
-}
-
-// OFFSET: LEGO1 0x100c32e0 TEMPLATE
-// MxCollection<MxRegionTopBottom *>::Compare
-
-// OFFSET: LEGO1 0x100c3340 TEMPLATE
-// MxCollection<MxRegionTopBottom *>::Destroy
 
 // OFFSET: LEGO1 0x100c34d0 TEMPLATE
 // MxCollection<MxRegionTopBottom *>::`scalar deleting destructor'
@@ -38,6 +32,12 @@ void MxRegionLeftRightList::Destroy(MxRegionLeftRight* p_leftRight)
 
 // OFFSET: LEGO1 0x100c4de0 TEMPLATE
 // MxCollection<MxRegionLeftRight *>::Destroy
+
+// OFFSET: LEGO1 0x100c4e80
+void MxRegionLeftRightList::Destroy(MxRegionLeftRight* p_leftRight)
+{
+	delete p_leftRight;
+}
 
 // OFFSET: LEGO1 0x100c4f50 TEMPLATE
 // MxCollection<MxRegionLeftRight *>::`scalar deleting destructor'

--- a/LEGO1/mxsmkpresenter.cpp
+++ b/LEGO1/mxsmkpresenter.cpp
@@ -41,6 +41,11 @@ void MxSmkPresenter::Destroy(MxBool p_fromDestructor)
 	}
 }
 
+// OFFSET: LEGO1 0x100b3940 STUB
+void MxSmkPresenter::VTable0x5c(undefined4 p_unknown1)
+{
+}
+
 // OFFSET: LEGO1 0x100b3960
 void MxSmkPresenter::VTable0x60()
 {
@@ -52,43 +57,9 @@ void MxSmkPresenter::VTable0x60()
 	m_bitmap->SetSize(m_mxSmack.m_smack.m_width, m_mxSmack.m_smack.m_height, NULL, FALSE);
 }
 
-// OFFSET: LEGO1 0x100c5d40
-void MxSmkPresenter::FUN_100c5d40(MxSmack* p_mxSmack)
-{
-	if (p_mxSmack->m_unk0x6a0)
-		delete p_mxSmack->m_unk0x6a0;
-	if (p_mxSmack->m_unk0x6a4)
-		delete p_mxSmack->m_unk0x6a4;
-	if (p_mxSmack->m_unk0x6a8)
-		delete p_mxSmack->m_unk0x6a8;
-	if (p_mxSmack->m_unk0x6ac)
-		delete p_mxSmack->m_unk0x6ac;
-	if (p_mxSmack->m_unk0x6b4)
-		delete p_mxSmack->m_unk0x6b4;
-}
-
-// OFFSET: LEGO1 0x100b4300
-void MxSmkPresenter::Destroy()
-{
-	Destroy(FALSE);
-}
-
-// OFFSET: LEGO1 0x100b3940 STUB
-void MxSmkPresenter::VTable0x5c(undefined4 p_unknown1)
-{
-}
-
 // OFFSET: LEGO1 0x100b3a00 STUB
 void MxSmkPresenter::VTable0x68(undefined4 p_unknown1)
 {
-}
-
-// OFFSET: LEGO1 0x100b42c0
-void MxSmkPresenter::VTable0x70()
-{
-	MxPalette* palette = m_bitmap->CreatePalette();
-	MVideoManager()->RealizePalette(palette);
-	delete palette;
 }
 
 // OFFSET: LEGO1 0x100b4260
@@ -110,4 +81,33 @@ MxU32 MxSmkPresenter::VTable0x88()
 		}
 		return result;
 	}
+}
+
+// OFFSET: LEGO1 0x100b42c0
+void MxSmkPresenter::VTable0x70()
+{
+	MxPalette* palette = m_bitmap->CreatePalette();
+	MVideoManager()->RealizePalette(palette);
+	delete palette;
+}
+
+// OFFSET: LEGO1 0x100b4300
+void MxSmkPresenter::Destroy()
+{
+	Destroy(FALSE);
+}
+
+// OFFSET: LEGO1 0x100c5d40
+void MxSmkPresenter::FUN_100c5d40(MxSmack* p_mxSmack)
+{
+	if (p_mxSmack->m_unk0x6a0)
+		delete p_mxSmack->m_unk0x6a0;
+	if (p_mxSmack->m_unk0x6a4)
+		delete p_mxSmack->m_unk0x6a4;
+	if (p_mxSmack->m_unk0x6a8)
+		delete p_mxSmack->m_unk0x6a8;
+	if (p_mxSmack->m_unk0x6ac)
+		delete p_mxSmack->m_unk0x6ac;
+	if (p_mxSmack->m_unk0x6b4)
+		delete p_mxSmack->m_unk0x6b4;
 }

--- a/LEGO1/mxstreamcontroller.cpp
+++ b/LEGO1/mxstreamcontroller.cpp
@@ -6,6 +6,24 @@
 
 DECOMP_SIZE_ASSERT(MxNextActionDataStart, 0x14)
 
+// OFFSET: LEGO1 0x100b9400
+MxResult MxStreamController::vtable0x18(undefined4 p_unknown, undefined4 p_unknown2)
+{
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100b9410
+MxResult MxStreamController::vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2)
+{
+	return FAILURE;
+}
+
+// OFFSET: LEGO1 0x100b9420
+MxResult MxStreamController::vtable0x28()
+{
+	return SUCCESS;
+}
+
 // OFFSET: LEGO1 0x100c0b90 STUB
 MxStreamController::MxStreamController()
 {
@@ -18,13 +36,6 @@ MxStreamController::~MxStreamController()
 	// TODO
 }
 
-// OFFSET: LEGO1 0x100c20d0 STUB
-MxBool MxStreamController::FUN_100c20d0(MxDSObject& p_obj)
-{
-	// TODO
-	return TRUE;
-}
-
 // OFFSET: LEGO1 0x100c1520
 MxResult MxStreamController::Open(const char* p_filename)
 {
@@ -34,18 +45,6 @@ MxResult MxStreamController::Open(const char* p_filename)
 	MakeSourceName(sourceName, p_filename);
 	this->atom = MxAtomId(sourceName, LookupMode_LowerCase2);
 	return SUCCESS;
-}
-
-// OFFSET: LEGO1 0x100b9400
-MxResult MxStreamController::vtable0x18(undefined4 p_unknown, undefined4 p_unknown2)
-{
-	return FAILURE;
-}
-
-// OFFSET: LEGO1 0x100b9410
-MxResult MxStreamController::vtable0x1C(undefined4 p_unknown, undefined4 p_unknown2)
-{
-	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c1690
@@ -89,10 +88,10 @@ MxResult MxStreamController::FUN_100c1800(MxDSAction* p_action, MxU32 p_val)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100b9420
-MxResult MxStreamController::vtable0x28()
+// OFFSET: LEGO1 0x100c1a00 STUB
+MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_bufferval)
 {
-	return SUCCESS;
+	return FAILURE;
 }
 
 // OFFSET: LEGO1 0x100c1c10
@@ -111,8 +110,9 @@ MxResult MxStreamController::vtable0x30(undefined4 p_unknown)
 	return FAILURE;
 }
 
-// OFFSET: LEGO1 0x100c1a00 STUB
-MxResult MxStreamController::FUN_100c1a00(MxDSAction* p_action, MxU32 p_bufferval)
+// OFFSET: LEGO1 0x100c20d0 STUB
+MxBool MxStreamController::FUN_100c20d0(MxDSObject& p_obj)
 {
-	return FAILURE;
+	// TODO
+	return TRUE;
 }

--- a/LEGO1/mxtimer.cpp
+++ b/LEGO1/mxtimer.cpp
@@ -17,6 +17,13 @@ MxTimer::MxTimer()
 	s_LastTimeCalculated = m_startTime;
 }
 
+// OFFSET: LEGO1 0x100ae140
+MxLong MxTimer::GetRealTime()
+{
+	MxTimer::s_LastTimeCalculated = timeGetTime();
+	return MxTimer::s_LastTimeCalculated - this->m_startTime;
+}
+
 // OFFSET: LEGO1 0x100ae160
 void MxTimer::Start()
 {
@@ -32,11 +39,4 @@ void MxTimer::Stop()
 	this->m_isRunning = FALSE;
 	// this feels very stupid but it's what the assembly does
 	this->m_startTime = this->m_startTime + startTime - 5;
-}
-
-// OFFSET: LEGO1 0x100ae140
-MxLong MxTimer::GetRealTime()
-{
-	MxTimer::s_LastTimeCalculated = timeGetTime();
-	return MxTimer::s_LastTimeCalculated - this->m_startTime;
 }

--- a/LEGO1/mxvariabletable.cpp
+++ b/LEGO1/mxvariabletable.cpp
@@ -1,5 +1,29 @@
 #include "mxvariabletable.h"
 
+// OFFSET: LEGO1 0x100afcd0 TEMPLATE
+// MxCollection<MxVariable *>::Compare
+
+// OFFSET: LEGO1 0x100afce0 TEMPLATE
+// MxCollection<MxVariable *>::~MxCollection<MxVariable *>
+
+// OFFSET: LEGO1 0x100afd30 TEMPLATE
+// MxCollection<MxVariable *>::Destroy
+
+// OFFSET: LEGO1 0x100afd40 TEMPLATE
+// MxCollection<MxVariable *>::`scalar deleting destructor'
+
+// OFFSET: LEGO1 0x100afdb0 TEMPLATE
+// MxVariableTable::Destroy
+
+// OFFSET: LEGO1 0x100afdc0 TEMPLATE
+// MxHashTable<MxVariable *>::Hash
+
+// OFFSET: LEGO1 0x100b0bd0 TEMPLATE
+// MxHashTable<MxVariable *>::~MxHashTable<MxVariable *>
+
+// OFFSET: LEGO1 0x100b0ca0 TEMPLATE
+// MxHashTable<MxVariable *>::`scalar deleting destructor'
+
 // OFFSET: LEGO1 0x100b7330
 MxS8 MxVariableTable::Compare(MxVariable* p_var0, MxVariable* p_var1)
 {
@@ -64,3 +88,9 @@ const char* MxVariableTable::GetVariable(const char* p_key)
 
 	return value;
 }
+
+// OFFSET: LEGO1 0x100b7ab0 TEMPLATE
+// MxHashTable<MxVariable *>::Resize
+
+// OFFSET: LEGO1 0x100b7b80 TEMPLATE
+// MxHashTable<MxVariable *>::_NodeInsert

--- a/LEGO1/mxvariabletable.h
+++ b/LEGO1/mxvariabletable.h
@@ -14,39 +14,11 @@ public:
 	__declspec(dllexport) void SetVariable(MxVariable* p_var);
 	__declspec(dllexport) const char* GetVariable(const char* p_key);
 
-	// OFFSET: LEGO1 0x100afdb0
 	static void Destroy(MxVariable* p_obj) { p_obj->Destroy(); }
 
 	virtual MxS8 Compare(MxVariable*, MxVariable*) override; // vtable+0x14
 	virtual MxU32 Hash(MxVariable*) override;                // vtable+0x18
 };
-
-// OFFSET: LEGO1 0x100afcd0 TEMPLATE
-// MxCollection<MxVariable *>::Compare
-
-// OFFSET: LEGO1 0x100afce0 TEMPLATE
-// MxCollection<MxVariable *>::~MxCollection<MxVariable *>
-
-// OFFSET: LEGO1 0x100afd30 TEMPLATE
-// MxCollection<MxVariable *>::Destroy
-
-// OFFSET: LEGO1 0x100afd40 TEMPLATE
-// MxCollection<MxVariable *>::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x100afdc0 TEMPLATE
-// MxHashTable<MxVariable *>::Hash
-
-// OFFSET: LEGO1 0x100b0bd0 TEMPLATE
-// MxHashTable<MxVariable *>::~MxHashTable<MxVariable *>
-
-// OFFSET: LEGO1 0x100b0ca0 TEMPLATE
-// MxHashTable<MxVariable *>::`scalar deleting destructor'
-
-// OFFSET: LEGO1 0x100b7ab0 TEMPLATE
-// MxHashTable<MxVariable *>::Resize
-
-// OFFSET: LEGO1 0x100b7b80 TEMPLATE
-// MxHashTable<MxVariable *>::_NodeInsert
 
 // VTABLE 0x100dc1b0 TEMPLATE
 // class MxCollection<MxVariable *>

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -44,17 +44,11 @@ MxVideoParam::MxVideoParam(MxVideoParam& p_videoParam)
 	SetDeviceName(p_videoParam.m_deviceId);
 }
 
-// OFFSET: LEGO1 0x100bede0
-MxVideoParam& MxVideoParam::operator=(const MxVideoParam& p_videoParam)
+// OFFSET: LEGO1 0x100bed50
+MxVideoParam::~MxVideoParam()
 {
-	this->m_rect = p_videoParam.m_rect;
-	this->m_palette = p_videoParam.m_palette;
-	this->m_backBuffers = p_videoParam.m_backBuffers;
-	this->m_flags = p_videoParam.m_flags;
-	this->m_unk1c = p_videoParam.m_unk1c;
-	SetDeviceName(p_videoParam.m_deviceId);
-
-	return *this;
+	if (this->m_deviceId != NULL)
+		delete[] this->m_deviceId;
 }
 
 // OFFSET: LEGO1 0x100bed70
@@ -75,9 +69,15 @@ void MxVideoParam::SetDeviceName(char* id)
 	}
 }
 
-// OFFSET: LEGO1 0x100bed50
-MxVideoParam::~MxVideoParam()
+// OFFSET: LEGO1 0x100bede0
+MxVideoParam& MxVideoParam::operator=(const MxVideoParam& p_videoParam)
 {
-	if (this->m_deviceId != NULL)
-		delete[] this->m_deviceId;
+	this->m_rect = p_videoParam.m_rect;
+	this->m_palette = p_videoParam.m_palette;
+	this->m_backBuffers = p_videoParam.m_backBuffers;
+	this->m_flags = p_videoParam.m_flags;
+	this->m_unk1c = p_videoParam.m_unk1c;
+	SetDeviceName(p_videoParam.m_deviceId);
+
+	return *this;
 }

--- a/LEGO1/realtime/matrix.cpp
+++ b/LEGO1/realtime/matrix.cpp
@@ -138,7 +138,7 @@ void Matrix4Impl::ToQuaternion(Vector4Impl* p_outQuat)
 		return;
 	}
 
-	// OFFSET: LEGO1 0x100d4090
+	// 0x100d4090
 	static int rotateIndex[] = {1, 2, 0};
 
 	// Largest element along the trace

--- a/LEGO1/realtime/realtimeview.cpp
+++ b/LEGO1/realtime/realtimeview.cpp
@@ -14,6 +14,19 @@ float g_userMaxLod = 3.6f;
 // 0x1010104c
 float g_partsThreshold = 1000.0f;
 
+// OFFSET: LEGO1 0x100a5de0
+void RealtimeView::SetUserMaxLOD(float p_lod)
+{
+	g_userMaxLod = p_lod;
+	UpdateMaxLOD();
+}
+
+// OFFSET: LEGO1 0x100a5df0
+void RealtimeView::SetPartsThreshold(float p_threshold)
+{
+	g_partsThreshold = p_threshold;
+}
+
 // OFFSET: LEGO1 0x100a5e00
 float RealtimeView::GetUserMaxLOD()
 {
@@ -27,21 +40,8 @@ float RealtimeView::GetPartsThreshold()
 	return g_partsThreshold;
 }
 
-// OFFSET: LEGO1 100a5e20
+// OFFSET: LEGO1 0x100a5e20
 void RealtimeView::UpdateMaxLOD()
 {
 	g_userMaxLodPower = pow(g_userMaxBase, -g_userMaxLod);
-}
-
-// OFFSET: LEGO1 0x100a5de0
-void RealtimeView::SetUserMaxLOD(float p_lod)
-{
-	g_userMaxLod = p_lod;
-	UpdateMaxLOD();
-}
-
-// OFFSET: LEGO1 0x100a5df0
-void RealtimeView::SetPartsThreshold(float p_threshold)
-{
-	g_partsThreshold = p_threshold;
 }

--- a/LEGO1/realtime/vector.cpp
+++ b/LEGO1/realtime/vector.cpp
@@ -12,10 +12,63 @@ DECOMP_SIZE_ASSERT(Vector4Impl, 0x8);
 DECOMP_SIZE_ASSERT(Vector3Data, 0x14);
 DECOMP_SIZE_ASSERT(Vector4Data, 0x18);
 
-// OFFSET: LEGO1 0x100020a0
-const float* Vector2Impl::GetData() const
+// OFFSET: LEGO1 0x10001f80
+void Vector2Impl::AddVectorImpl(float* p_value)
 {
-	return m_data;
+	m_data[0] += p_value[0];
+	m_data[1] += p_value[1];
+}
+
+// OFFSET: LEGO1 0x10001fa0
+void Vector2Impl::AddScalarImpl(float p_value)
+{
+	m_data[0] += p_value;
+	m_data[1] += p_value;
+}
+
+// OFFSET: LEGO1 0x10001fc0
+void Vector2Impl::SubVectorImpl(float* p_value)
+{
+	m_data[0] -= p_value[0];
+	m_data[1] -= p_value[1];
+}
+
+// OFFSET: LEGO1 0x10001fe0
+void Vector2Impl::MullVectorImpl(float* p_value)
+{
+	m_data[0] *= p_value[0];
+	m_data[1] *= p_value[1];
+}
+
+// OFFSET: LEGO1 0x10002000
+void Vector2Impl::MullScalarImpl(float* p_value)
+{
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
+}
+
+// OFFSET: LEGO1 0x10002020
+void Vector2Impl::DivScalarImpl(float* p_value)
+{
+	m_data[0] /= *p_value;
+	m_data[1] /= *p_value;
+}
+
+// OFFSET: LEGO1 0x10002040
+float Vector2Impl::DotImpl(float* p_a, float* p_b) const
+{
+	return p_b[0] * p_a[0] + p_b[1] * p_a[1];
+}
+
+// OFFSET: LEGO1 0x10002060 TEMPLATE
+// Vector2Impl::SetData
+
+// OFFSET: LEGO1 0x10002070
+void Vector2Impl::EqualsImpl(float* p_data)
+{
+	float* vec = m_data;
+	vec[0] = p_data[0];
+	vec[1] = p_data[1];
 }
 
 // OFFSET: LEGO1 0x10002090
@@ -24,16 +77,24 @@ float* Vector2Impl::GetData()
 	return m_data;
 }
 
-// OFFSET: LEGO1 0x10002130
-float Vector2Impl::Dot(Vector2Impl* p_a, float* p_b) const
+// OFFSET: LEGO1 0x100020a0
+const float* Vector2Impl::GetData() const
 {
-	return DotImpl(p_a->m_data, p_b);
+	return m_data;
 }
 
-// OFFSET: LEGO1 0x10002110
-float Vector2Impl::Dot(float* p_a, Vector2Impl* p_b) const
+// OFFSET: LEGO1 0x100020b0
+void Vector2Impl::Clear()
 {
-	return DotImpl(p_a, p_b->m_data);
+	float* vec = m_data;
+	vec[0] = 0.0f;
+	vec[1] = 0.0f;
+}
+
+// OFFSET: LEGO1 0x100020d0
+float Vector2Impl::Dot(float* p_a, float* p_b) const
+{
+	return DotImpl(p_a, p_b);
 }
 
 // OFFSET: LEGO1 0x100020f0
@@ -42,10 +103,22 @@ float Vector2Impl::Dot(Vector2Impl* p_a, Vector2Impl* p_b) const
 	return DotImpl(p_a->m_data, p_b->m_data);
 }
 
-// OFFSET: LEGO1 0x100020d0
-float Vector2Impl::Dot(float* p_a, float* p_b) const
+// OFFSET: LEGO1 0x10002110
+float Vector2Impl::Dot(float* p_a, Vector2Impl* p_b) const
 {
-	return DotImpl(p_a, p_b);
+	return DotImpl(p_a, p_b->m_data);
+}
+
+// OFFSET: LEGO1 0x10002130
+float Vector2Impl::Dot(Vector2Impl* p_a, float* p_b) const
+{
+	return DotImpl(p_a->m_data, p_b);
+}
+
+// OFFSET: LEGO1 0x10002150
+float Vector2Impl::LenSquared() const
+{
+	return m_data[0] * m_data[0] + m_data[1] * m_data[1];
 }
 
 // OFFSET: LEGO1 0x10002160
@@ -62,10 +135,10 @@ int Vector2Impl::Unitize()
 	return -1;
 }
 
-// OFFSET: LEGO1 0x100021e0
-void Vector2Impl::AddVector(Vector2Impl* p_other)
+// OFFSET: LEGO1 0x100021c0
+void Vector2Impl::AddScalar(float p_value)
 {
-	AddVectorImpl(p_other->m_data);
+	AddScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x100021d0
@@ -74,16 +147,10 @@ void Vector2Impl::AddVector(float* p_other)
 	AddVectorImpl(p_other);
 }
 
-// OFFSET: LEGO1 0x100021c0
-void Vector2Impl::AddScalar(float p_value)
+// OFFSET: LEGO1 0x100021e0
+void Vector2Impl::AddVector(Vector2Impl* p_other)
 {
-	AddScalarImpl(p_value);
-}
-
-// OFFSET: LEGO1 0x10002200
-void Vector2Impl::SubVector(Vector2Impl* p_other)
-{
-	SubVectorImpl(p_other->m_data);
+	AddVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x100021f0
@@ -92,16 +159,10 @@ void Vector2Impl::SubVector(float* p_other)
 	SubVectorImpl(p_other);
 }
 
-// OFFSET: LEGO1 0x10002230
-void Vector2Impl::MullScalar(float* p_value)
+// OFFSET: LEGO1 0x10002200
+void Vector2Impl::SubVector(Vector2Impl* p_other)
 {
-	MullScalarImpl(p_value);
-}
-
-// OFFSET: LEGO1 0x10002220
-void Vector2Impl::MullVector(Vector2Impl* p_other)
-{
-	MullVectorImpl(p_other->m_data);
+	SubVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002210
@@ -110,16 +171,22 @@ void Vector2Impl::MullVector(float* p_other)
 	MullVectorImpl(p_other);
 }
 
+// OFFSET: LEGO1 0x10002220
+void Vector2Impl::MullVector(Vector2Impl* p_other)
+{
+	MullVectorImpl(p_other->m_data);
+}
+
+// OFFSET: LEGO1 0x10002230
+void Vector2Impl::MullScalar(float* p_value)
+{
+	MullScalarImpl(p_value);
+}
+
 // OFFSET: LEGO1 0x10002240
 void Vector2Impl::DivScalar(float* p_value)
 {
 	DivScalarImpl(p_value);
-}
-
-// OFFSET: LEGO1 0x10002260
-void Vector2Impl::SetVector(Vector2Impl* p_other)
-{
-	EqualsImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002250
@@ -128,82 +195,182 @@ void Vector2Impl::SetVector(float* p_other)
 	EqualsImpl(p_other);
 }
 
-// OFFSET: LEGO1 0x10001fa0
-void Vector2Impl::AddScalarImpl(float p_value)
+// OFFSET: LEGO1 0x10002260
+void Vector2Impl::SetVector(Vector2Impl* p_other)
 {
-	m_data[0] += p_value;
-	m_data[1] += p_value;
+	EqualsImpl(p_other->m_data);
 }
 
-// OFFSET: LEGO1 0x10001f80
-void Vector2Impl::AddVectorImpl(float* p_value)
+// OFFSET: LEGO1 0x10002270
+void Vector3Impl::EqualsCrossImpl(float* p_a, float* p_b)
+{
+	m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
+	m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
+	m_data[2] = p_a[0] * p_b[1] - p_a[1] * p_b[0];
+}
+
+// OFFSET: LEGO1 0x100022c0
+void Vector3Impl::EqualsCross(Vector3Impl* p_a, Vector3Impl* p_b)
+{
+	EqualsCrossImpl(p_a->m_data, p_b->m_data);
+}
+
+// OFFSET: LEGO1 0x100022e0
+void Vector3Impl::EqualsCross(Vector3Impl* p_a, float* p_b)
+{
+	EqualsCrossImpl(p_a->m_data, p_b);
+}
+
+// OFFSET: LEGO1 0x10002300
+void Vector3Impl::EqualsCross(float* p_a, Vector3Impl* p_b)
+{
+	EqualsCrossImpl(p_a, p_b->m_data);
+}
+
+// OFFSET: LEGO1 0x10002870
+void Vector4Impl::AddVectorImpl(float* p_value)
 {
 	m_data[0] += p_value[0];
 	m_data[1] += p_value[1];
+	m_data[2] += p_value[2];
+	m_data[3] += p_value[3];
 }
 
-// OFFSET: LEGO1 0x10001fc0
-void Vector2Impl::SubVectorImpl(float* p_value)
-{
-	m_data[0] -= p_value[0];
-	m_data[1] -= p_value[1];
-}
-
-// OFFSET: LEGO1 0x10002000
-void Vector2Impl::MullScalarImpl(float* p_value)
-{
-	m_data[0] *= *p_value;
-	m_data[1] *= *p_value;
-}
-
-// OFFSET: LEGO1 0x10001fe0
-void Vector2Impl::MullVectorImpl(float* p_value)
-{
-	m_data[0] *= p_value[0];
-	m_data[1] *= p_value[1];
-}
-
-// OFFSET: LEGO1 0x10002020
-void Vector2Impl::DivScalarImpl(float* p_value)
-{
-	m_data[0] /= *p_value;
-	m_data[1] /= *p_value;
-}
-
-// OFFSET: LEGO1 0x10002040
-float Vector2Impl::DotImpl(float* p_a, float* p_b) const
-{
-	return p_b[0] * p_a[0] + p_b[1] * p_a[1];
-}
-
-// OFFSET: LEGO1 0x10002070
-void Vector2Impl::EqualsImpl(float* p_data)
-{
-	float* vec = m_data;
-	vec[0] = p_data[0];
-	vec[1] = p_data[1];
-}
-
-// OFFSET: LEGO1 0x100020b0
-void Vector2Impl::Clear()
-{
-	float* vec = m_data;
-	vec[0] = 0.0f;
-	vec[1] = 0.0f;
-}
-
-// OFFSET: LEGO1 0x10002150
-float Vector2Impl::LenSquared() const
-{
-	return m_data[0] * m_data[0] + m_data[1] * m_data[1];
-}
-
-// OFFSET: LEGO1 0x10003a90
-void Vector3Impl::AddScalarImpl(float p_value)
+// OFFSET: LEGO1 0x100028b0
+void Vector4Impl::AddScalarImpl(float p_value)
 {
 	m_data[0] += p_value;
 	m_data[1] += p_value;
 	m_data[2] += p_value;
+	m_data[3] += p_value;
+}
+
+// OFFSET: LEGO1 0x100028f0
+void Vector4Impl::SubVectorImpl(float* p_value)
+{
+	m_data[0] -= p_value[0];
+	m_data[1] -= p_value[1];
+	m_data[2] -= p_value[2];
+	m_data[3] -= p_value[3];
+}
+
+// OFFSET: LEGO1 0x10002930
+void Vector4Impl::MullVectorImpl(float* p_value)
+{
+	m_data[0] *= p_value[0];
+	m_data[1] *= p_value[1];
+	m_data[2] *= p_value[2];
+	m_data[3] *= p_value[3];
+}
+
+// OFFSET: LEGO1 0x10002970
+void Vector4Impl::MullScalarImpl(float* p_value)
+{
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
+	m_data[2] *= *p_value;
+	m_data[3] *= *p_value;
+}
+
+// OFFSET: LEGO1 0x100029b0
+void Vector4Impl::DivScalarImpl(float* p_value)
+{
+	m_data[0] /= *p_value;
+	m_data[1] /= *p_value;
+	m_data[2] /= *p_value;
+	m_data[3] /= *p_value;
+}
+
+// OFFSET: LEGO1 0x100029f0
+float Vector4Impl::DotImpl(float* p_a, float* p_b) const
+{
+	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
+}
+
+// OFFSET: LEGO1 0x10002a20
+void Vector4Impl::EqualsImpl(float* p_data)
+{
+	float* vec = m_data;
+	vec[0] = p_data[0];
+	vec[1] = p_data[1];
+	vec[2] = p_data[2];
+	vec[3] = p_data[3];
+}
+
+// OFFSET: LEGO1 0x10002a40
+void Vector4Impl::SetMatrixProductImpl(float* p_vec, float* p_mat)
+{
+	m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
+	m_data[1] = p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] + p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
+	m_data[2] = p_vec[0] * p_mat[2] + p_vec[1] * p_mat[6] + p_vec[2] * p_mat[10] + p_vec[4] * p_mat[14];
+	m_data[3] = p_vec[0] * p_mat[3] + p_vec[1] * p_mat[7] + p_vec[2] * p_mat[11] + p_vec[4] * p_mat[15];
+}
+
+// OFFSET: LEGO1 0x10002ae0
+void Vector4Impl::SetMatrixProduct(Vector4Impl* p_a, float* p_b)
+{
+	SetMatrixProductImpl(p_a->m_data, p_b);
+}
+
+// OFFSET: LEGO1 0x10002b00
+void Vector4Impl::Clear()
+{
+	float* vec = m_data;
+	vec[0] = 0.0f;
+	vec[1] = 0.0f;
+	vec[2] = 0.0f;
+	vec[3] = 0.0f;
+}
+
+// OFFSET: LEGO1 0x10002b20
+float Vector4Impl::LenSquared() const
+{
+	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2] + m_data[3] * m_data[3];
+}
+
+// OFFSET: LEGO1 0x10002b40
+void Vector4Impl::EqualsScalar(float* p_value)
+{
+	m_data[0] = *p_value;
+	m_data[1] = *p_value;
+	m_data[2] = *p_value;
+	m_data[3] = *p_value;
+}
+
+// Note close yet, included because I'm at least confident I know what operation
+// it's trying to do.
+// OFFSET: LEGO1 0x10002b70 STUB
+int Vector4Impl::NormalizeQuaternion()
+{
+	float* v = m_data;
+	float magnitude = v[1] * v[1] + v[2] * v[2] + v[0] * v[0];
+	if (magnitude > 0.0f) {
+		float theta = v[3] * 0.5f;
+		v[3] = cos(theta);
+		float frac = sin(theta);
+		magnitude = frac / sqrt(magnitude);
+		v[0] *= magnitude;
+		v[1] *= magnitude;
+		v[2] *= magnitude;
+		return 0;
+	}
+	return -1;
+}
+
+// OFFSET: LEGO1 0x10002bf0
+void Vector4Impl::UnknownQuaternionOp(Vector4Impl* p_a, Vector4Impl* p_b)
+{
+	float* bDat = p_b->m_data;
+	float* aDat = p_a->m_data;
+
+	this->m_data[3] = aDat[3] * bDat[3] - (bDat[0] * aDat[0] + aDat[2] * bDat[2] + aDat[1] * aDat[1]);
+	this->m_data[0] = bDat[2] * aDat[1] - bDat[1] * aDat[2];
+	this->m_data[1] = aDat[2] * bDat[0] - bDat[2] * aDat[0];
+	this->m_data[2] = bDat[1] * aDat[0] - aDat[1] * bDat[0];
+
+	m_data[0] = p_b->m_data[3] * p_a->m_data[0] + p_a->m_data[3] * p_b->m_data[0] + m_data[0];
+	m_data[1] = p_b->m_data[1] * p_a->m_data[3] + p_a->m_data[1] * p_b->m_data[3] + m_data[1];
+	m_data[2] = p_b->m_data[2] * p_a->m_data[3] + p_a->m_data[2] * p_b->m_data[3] + m_data[2];
 }
 
 // OFFSET: LEGO1 0x10003a60
@@ -214,6 +381,14 @@ void Vector3Impl::AddVectorImpl(float* p_value)
 	m_data[2] += p_value[2];
 }
 
+// OFFSET: LEGO1 0x10003a90
+void Vector3Impl::AddScalarImpl(float p_value)
+{
+	m_data[0] += p_value;
+	m_data[1] += p_value;
+	m_data[2] += p_value;
+}
+
 // OFFSET: LEGO1 0x10003ac0
 void Vector3Impl::SubVectorImpl(float* p_value)
 {
@@ -222,20 +397,20 @@ void Vector3Impl::SubVectorImpl(float* p_value)
 	m_data[2] -= p_value[2];
 }
 
-// OFFSET: LEGO1 0x10003b20
-void Vector3Impl::MullScalarImpl(float* p_value)
-{
-	m_data[0] *= *p_value;
-	m_data[1] *= *p_value;
-	m_data[2] *= *p_value;
-}
-
 // OFFSET: LEGO1 0x10003af0
 void Vector3Impl::MullVectorImpl(float* p_value)
 {
 	m_data[0] *= p_value[0];
 	m_data[1] *= p_value[1];
 	m_data[2] *= p_value[2];
+}
+
+// OFFSET: LEGO1 0x10003b20
+void Vector3Impl::MullScalarImpl(float* p_value)
+{
+	m_data[0] *= *p_value;
+	m_data[1] *= *p_value;
+	m_data[2] *= *p_value;
 }
 
 // OFFSET: LEGO1 0x10003b50
@@ -276,182 +451,10 @@ float Vector3Impl::LenSquared() const
 	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2];
 }
 
-// OFFSET: LEGO1 0x10002270
-void Vector3Impl::EqualsCrossImpl(float* p_a, float* p_b)
-{
-	m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
-	m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
-	m_data[2] = p_a[0] * p_b[1] - p_a[1] * p_b[0];
-}
-
-// OFFSET: LEGO1 0x10002300
-void Vector3Impl::EqualsCross(float* p_a, Vector3Impl* p_b)
-{
-	EqualsCrossImpl(p_a, p_b->m_data);
-}
-
-// OFFSET: LEGO1 0x100022e0
-void Vector3Impl::EqualsCross(Vector3Impl* p_a, float* p_b)
-{
-	EqualsCrossImpl(p_a->m_data, p_b);
-}
-
-// OFFSET: LEGO1 0x100022c0
-void Vector3Impl::EqualsCross(Vector3Impl* p_a, Vector3Impl* p_b)
-{
-	EqualsCrossImpl(p_a->m_data, p_b->m_data);
-}
-
 // OFFSET: LEGO1 0x10003bf0
 void Vector3Impl::EqualsScalar(float* p_value)
 {
 	m_data[0] = *p_value;
 	m_data[1] = *p_value;
 	m_data[2] = *p_value;
-}
-
-// OFFSET: LEGO1 0x100028b0
-void Vector4Impl::AddScalarImpl(float p_value)
-{
-	m_data[0] += p_value;
-	m_data[1] += p_value;
-	m_data[2] += p_value;
-	m_data[3] += p_value;
-}
-
-// OFFSET: LEGO1 0x10002870
-void Vector4Impl::AddVectorImpl(float* p_value)
-{
-	m_data[0] += p_value[0];
-	m_data[1] += p_value[1];
-	m_data[2] += p_value[2];
-	m_data[3] += p_value[3];
-}
-
-// OFFSET: LEGO1 0x100028f0
-void Vector4Impl::SubVectorImpl(float* p_value)
-{
-	m_data[0] -= p_value[0];
-	m_data[1] -= p_value[1];
-	m_data[2] -= p_value[2];
-	m_data[3] -= p_value[3];
-}
-
-// OFFSET: LEGO1 0x10002970
-void Vector4Impl::MullScalarImpl(float* p_value)
-{
-	m_data[0] *= *p_value;
-	m_data[1] *= *p_value;
-	m_data[2] *= *p_value;
-	m_data[3] *= *p_value;
-}
-
-// OFFSET: LEGO1 0x10002930
-void Vector4Impl::MullVectorImpl(float* p_value)
-{
-	m_data[0] *= p_value[0];
-	m_data[1] *= p_value[1];
-	m_data[2] *= p_value[2];
-	m_data[3] *= p_value[3];
-}
-
-// OFFSET: LEGO1 0x100029b0
-void Vector4Impl::DivScalarImpl(float* p_value)
-{
-	m_data[0] /= *p_value;
-	m_data[1] /= *p_value;
-	m_data[2] /= *p_value;
-	m_data[3] /= *p_value;
-}
-
-// OFFSET: LEGO1 0x100029f0
-float Vector4Impl::DotImpl(float* p_a, float* p_b) const
-{
-	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
-}
-
-// OFFSET: LEGO1 0x10002a20
-void Vector4Impl::EqualsImpl(float* p_data)
-{
-	float* vec = m_data;
-	vec[0] = p_data[0];
-	vec[1] = p_data[1];
-	vec[2] = p_data[2];
-	vec[3] = p_data[3];
-}
-
-// OFFSET: LEGO1 0x10002b00
-void Vector4Impl::Clear()
-{
-	float* vec = m_data;
-	vec[0] = 0.0f;
-	vec[1] = 0.0f;
-	vec[2] = 0.0f;
-	vec[3] = 0.0f;
-}
-
-// OFFSET: LEGO1 0x10002b20
-float Vector4Impl::LenSquared() const
-{
-	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2] + m_data[3] * m_data[3];
-}
-
-// OFFSET: LEGO1 0x10002b40
-void Vector4Impl::EqualsScalar(float* p_value)
-{
-	m_data[0] = *p_value;
-	m_data[1] = *p_value;
-	m_data[2] = *p_value;
-	m_data[3] = *p_value;
-}
-
-// OFFSET: LEGO1 0x10002ae0
-void Vector4Impl::SetMatrixProduct(Vector4Impl* p_a, float* p_b)
-{
-	SetMatrixProductImpl(p_a->m_data, p_b);
-}
-
-// OFFSET: LEGO1 0x10002a40
-void Vector4Impl::SetMatrixProductImpl(float* p_vec, float* p_mat)
-{
-	m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
-	m_data[1] = p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] + p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
-	m_data[2] = p_vec[0] * p_mat[2] + p_vec[1] * p_mat[6] + p_vec[2] * p_mat[10] + p_vec[4] * p_mat[14];
-	m_data[3] = p_vec[0] * p_mat[3] + p_vec[1] * p_mat[7] + p_vec[2] * p_mat[11] + p_vec[4] * p_mat[15];
-}
-
-// Note close yet, included because I'm at least confident I know what operation
-// it's trying to do.
-// OFFSET: LEGO1 0x10002b70 STUB
-int Vector4Impl::NormalizeQuaternion()
-{
-	float* v = m_data;
-	float magnitude = v[1] * v[1] + v[2] * v[2] + v[0] * v[0];
-	if (magnitude > 0.0f) {
-		float theta = v[3] * 0.5f;
-		v[3] = cos(theta);
-		float frac = sin(theta);
-		magnitude = frac / sqrt(magnitude);
-		v[0] *= magnitude;
-		v[1] *= magnitude;
-		v[2] *= magnitude;
-		return 0;
-	}
-	return -1;
-}
-
-// OFFSET: LEGO1 0x10002bf0
-void Vector4Impl::UnknownQuaternionOp(Vector4Impl* p_a, Vector4Impl* p_b)
-{
-	float* bDat = p_b->m_data;
-	float* aDat = p_a->m_data;
-
-	this->m_data[3] = aDat[3] * bDat[3] - (bDat[0] * aDat[0] + aDat[2] * bDat[2] + aDat[1] * aDat[1]);
-	this->m_data[0] = bDat[2] * aDat[1] - bDat[1] * aDat[2];
-	this->m_data[1] = aDat[2] * bDat[0] - bDat[2] * aDat[0];
-	this->m_data[2] = bDat[1] * aDat[0] - aDat[1] * bDat[0];
-
-	m_data[0] = p_b->m_data[3] * p_a->m_data[0] + p_a->m_data[3] * p_b->m_data[0] + m_data[0];
-	m_data[1] = p_b->m_data[1] * p_a->m_data[3] + p_a->m_data[1] * p_b->m_data[3] + m_data[1];
-	m_data[2] = p_b->m_data[2] * p_a->m_data[3] + p_a->m_data[2] * p_b->m_data[3] + m_data[2];
 }

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -3,6 +3,7 @@
 
 #include <vec.h>
 
+// TODO: Find proper compilation unit to put this
 // OFFSET: LEGO1 0x1000c0f0 TEMPLATE
 // Vector2Impl::Vector2Impl
 

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -3,6 +3,9 @@
 
 #include <vec.h>
 
+// OFFSET: LEGO1 0x1000c0f0 TEMPLATE
+// Vector2Impl::Vector2Impl
+
 /*
  * A simple array of three floats that can be indexed into.
  */
@@ -60,7 +63,6 @@ public:
 // SIZE 0x8
 class Vector2Impl {
 public:
-	// OFFSET: LEGO1 0x1000c0f0
 	inline Vector2Impl(float* p_data) { this->SetData(p_data); }
 
 	// vtable + 0x00 (no virtual destructor)
@@ -73,8 +75,6 @@ public:
 	virtual void MullVectorImpl(float* p_value) = 0;
 	virtual void DivScalarImpl(float* p_value) = 0;
 	virtual float DotImpl(float* p_a, float* p_b) const = 0;
-
-	// OFFSET: LEGO1 0x10002060
 	virtual void SetData(float* p_data) { this->m_data = p_data; }
 
 	// vtable + 0x20

--- a/LEGO1/score.cpp
+++ b/LEGO1/score.cpp
@@ -22,6 +22,12 @@ Score::Score()
 	NotificationManager()->Register(this);
 }
 
+// OFFSET: LEGO1 0x100010b0
+MxBool Score::VTable0x5c()
+{
+	return TRUE;
+}
+
 // OFFSET: LEGO1 0x10001200
 Score::~Score()
 {
@@ -30,6 +36,39 @@ Score::~Score()
 	InputManager()->UnRegister(this);
 	ControlManager()->Unregister(this);
 	NotificationManager()->Unregister(this);
+}
+
+// OFFSET: LEGO1 0x100012a0
+MxResult Score::Create(MxDSObject& p_dsObject)
+{
+	MxResult result = SetAsCurrentWorld(p_dsObject);
+
+	if (result == SUCCESS) {
+		InputManager()->SetWorld(this);
+		ControlManager()->Register(this);
+		InputManager()->Register(this);
+		SetIsWorldActive(FALSE);
+		LegoGameState* gs = GameState();
+		ScoreState* state = (ScoreState*) gs->GetState("ScoreState");
+		m_state = state ? state : (ScoreState*) gs->CreateState("ScoreState");
+		GameState()->SetUnknown424(0xd);
+		GameState()->FUN_1003a720(0);
+	}
+
+	return result;
+}
+
+// OFFSET: LEGO1 0x10001340
+void Score::DeleteScript()
+{
+	if (m_state->GetTutorialFlag()) {
+		MxDSAction action;
+		action.SetObjectId(0x1f5);
+		action.SetAtomId(*g_infoscorScript);
+		action.SetUnknown24(-2);
+		DeleteObject(action);
+		m_state->SetTutorialFlag(FALSE);
+	}
 }
 
 // OFFSET: LEGO1 0x10001410
@@ -65,45 +104,6 @@ MxLong Score::Notify(MxParam& p)
 		}
 	}
 	return ret;
-}
-
-// OFFSET: LEGO1 0x100010b0
-MxBool Score::VTable0x5c()
-{
-	return TRUE;
-}
-
-// OFFSET: LEGO1 0x100012a0
-MxResult Score::Create(MxDSObject& p_dsObject)
-{
-	MxResult result = SetAsCurrentWorld(p_dsObject);
-
-	if (result == SUCCESS) {
-		InputManager()->SetWorld(this);
-		ControlManager()->Register(this);
-		InputManager()->Register(this);
-		SetIsWorldActive(FALSE);
-		LegoGameState* gs = GameState();
-		ScoreState* state = (ScoreState*) gs->GetState("ScoreState");
-		m_state = state ? state : (ScoreState*) gs->CreateState("ScoreState");
-		GameState()->SetUnknown424(0xd);
-		GameState()->FUN_1003a720(0);
-	}
-
-	return result;
-}
-
-// OFFSET: LEGO1 0x10001340
-void Score::DeleteScript()
-{
-	if (m_state->GetTutorialFlag()) {
-		MxDSAction action;
-		action.SetObjectId(0x1f5);
-		action.SetAtomId(*g_infoscorScript);
-		action.SetUnknown24(-2);
-		DeleteObject(action);
-		m_state->SetTutorialFlag(FALSE);
-	}
 }
 
 // OFFSET: LEGO1 0x10001510


### PR DESCRIPTION
This PR fixes all the `checkorder.py` issues and adds a GitHub Action to enforce the order from now on.

What is still pending (but can be done separately / in a future PR) is to check/enforce that all `OFFSET` annotations should be in `.cpp` files. This mostly affects the `IsA`/`ClassName` functions - I've already converted those that needed fixing for `checkorder` to pass in this PR.

Interestingly just by bringing all the functions in correct order we have gained a significant accuracy bump (no code has changed):

```
-Total effective accuracy 61.13% across 1929 functions (60.56% actual accuracy)
+Total effective accuracy 61.56% across 1929 functions (60.98% actual accuracy)
```

Which supports the already known case that the order actually matters for final accuracy.